### PR TITLE
Add ADR-0011 to document removal of python-copier-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ ADRs document significant technical decisions:
 | ADR | Title |
 |-----|-------|
 | 0001 | Record architecture decisions |
-| 0002 | Switched to python-copier-template |
+| 0002 | Switched to python-copier-template (superseded by ADR-0011) |
 | 0003 | Message queue message grouping |
 | 0004 | Zocalo dependency-free |
 | 0005 | detect-secrets for secret scanning |
@@ -113,6 +113,7 @@ ADRs document significant technical decisions:
 | 0007 | Eliminate SmartEM API circular dependency |
 | 0008 | Backend to agent communication architecture |
 | 0009 | Commit generated route tree (smartem-frontend) |
+| 0011 | Remove python-copier-template |
 
 ## Contributing
 

--- a/docs/explanations/decisions/0002-switched-to-python-copier-template.md
+++ b/docs/explanations/decisions/0002-switched-to-python-copier-template.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted
+Superseded by ADR-0011
+
+> **Note**: This decision was reversed on 2026-01-05. See [ADR-0011](0011-remove-python-copier-template.md) for details.
 
 ## Context
 

--- a/docs/explanations/decisions/0011-remove-python-copier-template.md
+++ b/docs/explanations/decisions/0011-remove-python-copier-template.md
@@ -1,0 +1,55 @@
+# 11. Remove python-copier-template
+
+## Status
+
+Accepted
+
+## Context
+
+In ADR-0002, we adopted the [python-copier-template](https://github.com/DiamondLightSource/python-copier-template) to ensure consistency in developer environments and package management.
+
+Since that decision, the smartem-decisions project has evolved significantly:
+
+1. **Project maturity**: The project has grown from a single-package PoC to a multi-package monorepo with custom requirements that diverge from standard DLS Python projects
+2. **Custom tooling needs**: Our development workflow now requires tooling configurations specific to our architecture (multi-package structure, agent deployment, Kubernetes manifests, RabbitMQ integration)
+3. **Template update friction**: The copier template's update mechanism became a maintenance burden rather than a benefit, as most updates were not relevant to our custom structure
+4. **Duplicated documentation**: The template's contribution guidelines and developer documentation conflicted with our own evolving practices documented in smartem-devtools
+
+## Decision
+
+We have removed the python-copier-template dependency and scaffolding from smartem-decisions.
+
+The following were removed in commit f95b1de (2026-01-05):
+- `.copier-answers.yml` configuration file
+- Copier dependency from `pyproject.toml`
+- Template-generated sections from `.github/CONTRIBUTING.md`
+
+We retain the tooling standards established by the template (pyright, ruff, pre-commit) but now manage their configuration directly.
+
+## Consequences
+
+### Positive
+
+- **Reduced maintenance burden**: No need to resolve conflicts when updating from the template
+- **Custom workflows**: Freedom to evolve tooling and structure to match our specific needs
+- **Simplified onboarding**: Developer documentation is now solely in smartem-devtools, not split between template and repo
+- **Clearer ownership**: All configuration is explicitly managed by the team
+
+### Negative
+
+- **Manual updates**: We no longer automatically receive updates to best practices from the template
+- **Divergence risk**: May drift from DLS Python conventions over time
+- **Responsibility**: Must actively maintain tooling standards ourselves
+
+### Mitigations
+
+- Continue following DLS Python best practices where applicable
+- Reference the copier template repo for inspiration when updating tooling
+- Document our standards explicitly in smartem-devtools
+- Maintain pre-commit hooks to enforce code quality standards
+
+## References
+
+- ADR-0002: Adopt python-copier-template (superseded by this decision)
+- Removal commit: f95b1dea1479d8d845f5cfd605084c201f459020
+- DLS python-copier-template: https://github.com/DiamondLightSource/python-copier-template

--- a/webui/src/docs/explanations/decisions.mdx
+++ b/webui/src/docs/explanations/decisions.mdx
@@ -5,7 +5,7 @@ Architectural decisions are made throughout a project's lifetime. As a way of ke
 ## ADRs
 
 - [ADR-0001: Record Architecture Decisions](/docs/explanations/decisions/0001-record-architecture-decisions)
-- [ADR-0002: Switched to Python Copier Template](/docs/explanations/decisions/0002-switched-to-python-copier-template)
+- [ADR-0002: Switched to Python Copier Template (superseded by ADR-0011)](/docs/explanations/decisions/0002-switched-to-python-copier-template)
 - [ADR-0003: Message Queue Message Grouping](/docs/explanations/decisions/0003-message-queue-message-grouping)
 - [ADR-0004: Zocalo Dependency-Free](/docs/explanations/decisions/0004-zocalo-dependency-free)
 - [ADR-0005: Detect Secrets for Secret Scanning](/docs/explanations/decisions/0005-detect-secrets-for-secret-scanning)
@@ -13,5 +13,7 @@ Architectural decisions are made throughout a project's lifetime. As a way of ke
 - [ADR-0007: Eliminate SmartEM API Circular Dependency](/docs/explanations/decisions/0007-eliminate-smartem-api-circular-dependency)
 - [ADR-0008: Backend to Agent Communication Architecture](/docs/explanations/decisions/0008-backend-to-agent-communication-architecture)
 - [ADR-0009: Commit Generated Route Tree](/docs/explanations/decisions/0009-commit-generated-route-tree)
+- [ADR-0010: Use Shiki for Syntax Highlighting](/docs/explanations/decisions/0010-shiki-syntax-highlighting)
+- [ADR-0011: Remove Python Copier Template](/docs/explanations/decisions/0011-remove-python-copier-template)
 
 For more information on ADRs see this [blog by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).

--- a/webui/src/docs/explanations/decisions/0002-switched-to-python-copier-template.mdx
+++ b/webui/src/docs/explanations/decisions/0002-switched-to-python-copier-template.mdx
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted
+Superseded by ADR-0011
+
+> **Note**: This decision was reversed on 2026-01-05. See [ADR-0011](/docs/explanations/decisions/0011-remove-python-copier-template) for details.
 
 ## Context
 

--- a/webui/src/docs/explanations/decisions/0011-remove-python-copier-template.mdx
+++ b/webui/src/docs/explanations/decisions/0011-remove-python-copier-template.mdx
@@ -1,0 +1,55 @@
+# 11. Remove python-copier-template
+
+## Status
+
+Accepted
+
+## Context
+
+In ADR-0002, we adopted the [python-copier-template](https://github.com/DiamondLightSource/python-copier-template) to ensure consistency in developer environments and package management.
+
+Since that decision, the smartem-decisions project has evolved significantly:
+
+1. **Project maturity**: The project has grown from a single-package PoC to a multi-package monorepo with custom requirements that diverge from standard DLS Python projects
+2. **Custom tooling needs**: Our development workflow now requires tooling configurations specific to our architecture (multi-package structure, agent deployment, Kubernetes manifests, RabbitMQ integration)
+3. **Template update friction**: The copier template's update mechanism became a maintenance burden rather than a benefit, as most updates were not relevant to our custom structure
+4. **Duplicated documentation**: The template's contribution guidelines and developer documentation conflicted with our own evolving practices documented in smartem-devtools
+
+## Decision
+
+We have removed the python-copier-template dependency and scaffolding from smartem-decisions.
+
+The following were removed in commit f95b1de (2026-01-05):
+- `.copier-answers.yml` configuration file
+- Copier dependency from `pyproject.toml`
+- Template-generated sections from `.github/CONTRIBUTING.md`
+
+We retain the tooling standards established by the template (pyright, ruff, pre-commit) but now manage their configuration directly.
+
+## Consequences
+
+### Positive
+
+- **Reduced maintenance burden**: No need to resolve conflicts when updating from the template
+- **Custom workflows**: Freedom to evolve tooling and structure to match our specific needs
+- **Simplified onboarding**: Developer documentation is now solely in smartem-devtools, not split between template and repo
+- **Clearer ownership**: All configuration is explicitly managed by the team
+
+### Negative
+
+- **Manual updates**: We no longer automatically receive updates to best practices from the template
+- **Divergence risk**: May drift from DLS Python conventions over time
+- **Responsibility**: Must actively maintain tooling standards ourselves
+
+### Mitigations
+
+- Continue following DLS Python best practices where applicable
+- Reference the copier template repo for inspiration when updating tooling
+- Document our standards explicitly in smartem-devtools
+- Maintain pre-commit hooks to enforce code quality standards
+
+## References
+
+- ADR-0002: Adopt python-copier-template (superseded by this decision)
+- Removal commit: f95b1dea1479d8d845f5cfd605084c201f459020
+- DLS python-copier-template: https://github.com/DiamondLightSource/python-copier-template

--- a/webui/src/docs/navigation.ts
+++ b/webui/src/docs/navigation.ts
@@ -59,7 +59,7 @@ export const docsNavigation: NavItem[] = [
             href: '/docs/explanations/decisions/0001-record-architecture-decisions',
           },
           {
-            title: 'ADR-0002: Copier Template',
+            title: 'ADR-0002: Copier Template (superseded)',
             href: '/docs/explanations/decisions/0002-switched-to-python-copier-template',
           },
           {
@@ -93,6 +93,10 @@ export const docsNavigation: NavItem[] = [
           {
             title: 'ADR-0010: Shiki Highlighting',
             href: '/docs/explanations/decisions/0010-shiki-syntax-highlighting',
+          },
+          {
+            title: 'ADR-0011: Remove Copier Template',
+            href: '/docs/explanations/decisions/0011-remove-python-copier-template',
           },
         ],
       },


### PR DESCRIPTION
## Summary

This PR supersedes ADR-0002 (Adopt python-copier-template) with ADR-0011 (Remove python-copier-template), documenting the decision to remove copier-template scaffolding from smartem-decisions.

## Changes

- **Created ADR-0011**: Documents the removal of python-copier-template dependency and scaffolding (commit f95b1de in smartem-decisions)
- **Updated ADR-0002**: Marked as "Superseded by ADR-0011" with explanatory note
- **Updated README.md**: ADR table now shows supersession
- **Updated WebUI navigation**: Both navigation.ts and decisions.mdx updated
- **Bonus**: Added missing ADR-0010 (Shiki) to WebUI decisions index

## Context

The python-copier-template was originally adopted to ensure consistency across DLS Python projects. However, as smartem-decisions evolved into a multi-package monorepo with custom requirements, the template became a maintenance burden rather than a benefit. The template was removed in smartem-decisions on 2026-01-05 (commit f95b1de).

This PR ensures the documentation reflects this decision following ADR best practices - we don't delete old decisions, we supersede them with new ones that explain the rationale.

## Files Changed

- 2 new files: ADR-0011 in both Sphinx (.md) and WebUI (.mdx) formats
- 5 modified files: ADR-0002 status updates, README, navigation, and index

## Testing

- ✅ Pre-commit hooks passed (biome)
- ✅ Pre-push hooks passed (format-check, lint, typecheck)
- ✅ All copier-template references properly documented as superseded

## References

- smartem-decisions removal commit: f95b1dea1479d8d845f5cfd605084c201f459020
- ADR-0002: docs/explanations/decisions/0002-switched-to-python-copier-template.md