### PR TITLE
docs: add ADR-0014 for SmartEM release architecture

### DIFF
--- a/docs/decision-records/decisions/0014-smartem-release-architecture.md
+++ b/docs/decision-records/decisions/0014-smartem-release-architecture.md
@@ -53,15 +53,14 @@ Publish `smartem-decisions` to PyPI with optional dependency groups:
 ### Version Strategy
 
 - **Package version**: Derived from git tags using setuptools_scm
-- **Agent releases**: Tagged with `smartem-agent-v*` format
-- **Backend releases**: Future work with `smartem-backend-v*` tags
+- **Releases**: Tagged with `smartem-decisions-v*` format (unified for all components)
 - **Shared versioning**: All components share the same version for API compatibility
 
 ### Release Triggers
 
 | Event | Condition | Result |
 |-------|-----------|--------|
-| Tag `smartem-agent-v*` | Always | Stable release to GitHub + PyPI |
+| Tag `smartem-decisions-v*` | Always | Stable release to GitHub + PyPI |
 | Push to main | Agent paths changed | RC pre-release to GitHub only |
 | Pull request | Agent paths changed | Build + test validation only |
 


### PR DESCRIPTION
## Summary

Documents the release strategy for the smartem-decisions monorepo.

## Key Decisions

- **Single package with extras**: `smartem-decisions[agent]`, `[backend]`, `[common]`, etc.
- **Shared versioning**: All components use the same version via setuptools_scm
- **Dual distribution**: PyPI for Python users, Windows exe for EPU workstations
- **uv in CI**: 10-100x faster dependency installation

## Release Flow

```
Tag smartem-agent-v* → Stable release (GitHub + PyPI)
Push to main → RC pre-release (GitHub only)
PR → Validation build only
```

## Related

- Implementation PR: DiamondLightSource/smartem-decisions#213
- uv adoption: #15