### PR TITLE
feat: add PyPI links to artifacts and auto-deploy GH Pages

### DIFF
--- a/.github/workflows/deploy-webui.yml
+++ b/.github/workflows/deploy-webui.yml
@@ -2,6 +2,12 @@ name: Deploy WebUI to GitHub Pages
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'webui/**'
+      - 'core/**'
+      - 'docs/**'
 
 permissions:
   contents: read

--- a/core/artefacts.json
+++ b/core/artefacts.json
@@ -4,15 +4,25 @@
       "id": "backend",
       "label": "SmartEM Backend",
       "url": "https://github.com/DiamondLightSource/smartem-decisions/pkgs/container/smartem-decisions",
-      "description": "Docker container image of SmartEM Backend services for use in k8s deploys",
-      "command": "docker pull ghcr.io/diamondlightsource/smartem-decisions:latest"
+      "description": "Central controller for SmartEM - handles persistence, messaging, and coordination between microscope agents and ML plugins",
+      "command": "docker pull ghcr.io/diamondlightsource/smartem-decisions:latest",
+      "links": [
+        { "label": "GitHub Releases", "url": "https://github.com/DiamondLightSource/smartem-decisions/releases" },
+        { "label": "PyPI", "url": "https://pypi.org/project/smartem-decisions/" },
+        { "label": "Docker", "url": "https://github.com/DiamondLightSource/smartem-decisions/pkgs/container/smartem-decisions" }
+      ]
     },
     {
       "id": "agent",
       "label": "SmartEM Agent",
       "url": "https://github.com/DiamondLightSource/smartem-decisions/actions/workflows/build_win_smartem_agent.yml",
-      "description": "SmartEM Agent packaged as a Windows 10 executable (download from workflow artifacts)",
-      "command": ""
+      "description": "Bridge between EPU workstations and SmartEM backend - watches EPU filesystem output and relays ML recommendations to microscopes",
+      "command": "",
+      "links": [
+        { "label": "GitHub Releases", "url": "https://github.com/DiamondLightSource/smartem-decisions/releases" },
+        { "label": "PyPI", "url": "https://pypi.org/project/smartem-decisions/" },
+        { "label": "Windows .exe", "url": "https://github.com/DiamondLightSource/smartem-decisions/actions/workflows/build_win_smartem_agent.yml" }
+      ]
     },
     {
       "id": "frontend",
@@ -28,6 +38,7 @@
       "description": "CLI tool to automate multi-repo workspace setup",
       "command": "uvx smartem-workspace --help",
       "links": [
+        { "label": "GitHub Releases", "url": "https://github.com/DiamondLightSource/smartem-devtools/releases" },
         { "label": "PyPI", "url": "https://pypi.org/project/smartem-workspace/" }
       ]
     },
@@ -39,7 +50,8 @@
       "command": "uvx smartem-epuplayer --help",
       "links": [
         { "label": "GitHub Releases", "url": "https://github.com/DiamondLightSource/smartem-devtools/releases" },
-        { "label": "PyPI", "url": "https://pypi.org/project/smartem-epuplayer/" }
+        { "label": "PyPI", "url": "https://pypi.org/project/smartem-epuplayer/" },
+        { "label": "Windows .exe", "url": "https://github.com/DiamondLightSource/smartem-devtools/releases" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Add PyPI and GitHub Releases links to backend and agent artifacts in `core/artefacts.json`
- Enable automatic GH Pages deployment on push to main when `webui/`, `core/`, or `docs/` files change

## Test plan
- [x] Verify `artefacts.json` is valid JSON
- [x] Verify workflow YAML syntax is valid
- [ ] After merge, push a change to `webui/`, `core/`, or `docs/` and verify the deploy workflow triggers automatically
