### PR TITLE
fix: pass explicit config path to OSV scanner workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -20,7 +20,11 @@ jobs:
   scan-pr:
     if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'merge_group'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.2
+    with:
+      scan-args: '--config ./osv-scanner.toml -r ./'
 
   scan-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.2
+    with:
+      scan-args: '--config ./osv-scanner.toml -r ./'


### PR DESCRIPTION
## Summary

- Fix OSV scanner workflow failing to find ignore rules
- Add `--config` flag via `scan-args` to both scanner jobs

## Problem

The OSV scanner workflow fails because:
- `osv-scanner.toml` was moved from `webui/` to repo root in PR #145
- OSV scanner looks for config files relative to the lockfile location (`webui/package-lock.json`)
- The ignore rule for GHSA-73rr-hh4g-fpgx (cross-spawn) wasn't being found

## Solution

Pass `--config ./osv-scanner.toml` explicitly via `scan-args` to tell OSV scanner where to find the config file at repository root.

## Test plan

- [x] OSV scanner workflow passes on this PR
- [ ] Can verify manually: `gh workflow run osv-scanner.yml` after merge