### PR TITLE
feat: add security scanning tools to dev prerequisites

### DIFF
--- a/core/dev-requirements.json
+++ b/core/dev-requirements.json
@@ -68,6 +68,27 @@
       "versionArgs": ["--version"],
       "required": false,
       "description": "GitHub CLI"
+    },
+    {
+      "name": "pre-commit",
+      "command": "pre-commit",
+      "versionArgs": ["--version"],
+      "required": false,
+      "description": "Git hooks framework for code quality checks"
+    },
+    {
+      "name": "detect-secrets",
+      "command": "detect-secrets",
+      "versionArgs": ["--version"],
+      "required": false,
+      "description": "Secrets detection tool for baseline management"
+    },
+    {
+      "name": "osv-scanner",
+      "command": "osv-scanner",
+      "versionArgs": ["--version"],
+      "required": false,
+      "description": "Vulnerability scanner for dependencies"
     }
   ],
   "network": {

--- a/packages/smartem-workspace/smartem_workspace/config/dev-requirements.json
+++ b/packages/smartem-workspace/smartem_workspace/config/dev-requirements.json
@@ -68,6 +68,27 @@
       "versionArgs": ["--version"],
       "required": false,
       "description": "GitHub CLI"
+    },
+    {
+      "name": "pre-commit",
+      "command": "pre-commit",
+      "versionArgs": ["--version"],
+      "required": false,
+      "description": "Git hooks framework for code quality checks"
+    },
+    {
+      "name": "detect-secrets",
+      "command": "detect-secrets",
+      "versionArgs": ["--version"],
+      "required": false,
+      "description": "Secrets detection tool for baseline management"
+    },
+    {
+      "name": "osv-scanner",
+      "command": "osv-scanner",
+      "versionArgs": ["--version"],
+      "required": false,
+      "description": "Vulnerability scanner for dependencies"
     }
   ],
   "network": {


### PR DESCRIPTION
## Summary

- Add pre-commit, detect-secrets, and osv-scanner to dev prerequisite checks
- Keep both config files in sync (core/ and package fallback)

## Problem

PR #145 added security scanning tools (pre-commit hooks, detect-secrets baseline, osv-scanner) but didn't update the prerequisite check. Developers aren't warned when these tools are missing from their environment.

## Solution

Add the three tools to `dev-requirements.json`:
- **pre-commit**: Git hooks framework for code quality checks
- **detect-secrets**: Secrets detection tool for baseline management
- **osv-scanner**: Vulnerability scanner for dependencies

All marked as optional (`required: false`) since they're only needed for security scanning workflows, not core development.

## Test plan

- [ ] Run `smartem-workspace check --scope dev-requirements` with tools installed
- [ ] Run `smartem-workspace check --scope dev-requirements` with tools missing (should show warnings, not errors)