### PR TITLE
feat: add sqlite3 to dev requirements

### DIFF
--- a/core/dev-requirements.json
+++ b/core/dev-requirements.json
@@ -89,6 +89,13 @@
       "versionArgs": ["--version"],
       "required": false,
       "description": "Vulnerability scanner for dependencies"
+    },
+    {
+      "name": "sqlite3",
+      "command": "sqlite3",
+      "versionArgs": ["--version"],
+      "required": false,
+      "description": "SQLite CLI for inspecting local databases (fandanGO, etc.)"
     }
   ],
   "network": {


### PR DESCRIPTION
## Summary
- Adds sqlite3 CLI to dev-requirements.json as an optional tool
- Useful for inspecting local SQLite databases (fandanGO project data, etc.)

## Test plan
- Verify `sqlite3 --version` works on systems with it installed