### PR TITLE
feat: add local vulnerability scanning scripts

### DIFF
--- a/scripts/osv-scan-repos.sh
+++ b/scripts/osv-scan-repos.sh
@@ -38,19 +38,13 @@ OSV_SCANNER=$(find_osv_scanner)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ERIC_ROOT="${SCRIPT_DIR}/../../../.."
 
-DEFAULT_REPOS=(
-    "repos/DiamondLightSource/smartem-decisions"
-    "repos/DiamondLightSource/smartem-frontend"
-    "repos/DiamondLightSource/smartem-devtools"
-    "repos/DiamondLightSource/fandanGO-cryoem-dls"
-    "repos/FragmentScreen/fandanGO-aria"
-    "repos/FragmentScreen/fandanGO-core"
-    "repos/FragmentScreen/fandanGO-cryoem-cnb"
-    "repos/FragmentScreen/fandanGO-nmr-cerm"
-    "repos/FragmentScreen/fandanGO-nmr-guf"
-    "repos/FragmentScreen/ddapi-record-logs"
-    "repos/FragmentScreen/ddapi-record-oscem"
-)
+# Discover all repos in ERIC workspace (repos/*/* directories with .git)
+discover_repos() {
+    local repos_dir="${ERIC_ROOT}/repos"
+    if [[ -d "$repos_dir" ]]; then
+        find "$repos_dir" -mindepth 2 -maxdepth 2 -type d -exec test -d '{}/.git' \; -print | sort
+    fi
+}
 
 OUTPUT_FILE=""
 REPOS=()
@@ -79,11 +73,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Use default repos if none specified
+# Use discovered repos if none specified
 if [[ ${#REPOS[@]} -eq 0 ]]; then
-    for repo in "${DEFAULT_REPOS[@]}"; do
-        REPOS+=("${ERIC_ROOT}/${repo}")
-    done
+    while IFS= read -r repo; do
+        REPOS+=("$repo")
+    done < <(discover_repos)
 fi
 
 scan_repo() {

--- a/scripts/pip-audit-scan-repos.sh
+++ b/scripts/pip-audit-scan-repos.sh
@@ -18,19 +18,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ERIC_ROOT="${SCRIPT_DIR}/../../../.."
 
-DEFAULT_REPOS=(
-    "repos/DiamondLightSource/smartem-decisions"
-    "repos/DiamondLightSource/smartem-frontend"
-    "repos/DiamondLightSource/smartem-devtools"
-    "repos/DiamondLightSource/fandanGO-cryoem-dls"
-    "repos/FragmentScreen/fandanGO-aria"
-    "repos/FragmentScreen/fandanGO-core"
-    "repos/FragmentScreen/fandanGO-cryoem-cnb"
-    "repos/FragmentScreen/fandanGO-nmr-cerm"
-    "repos/FragmentScreen/fandanGO-nmr-guf"
-    "repos/FragmentScreen/ddapi-record-logs"
-    "repos/FragmentScreen/ddapi-record-oscem"
-)
+# Discover all repos in ERIC workspace (repos/*/* directories with .git)
+discover_repos() {
+    local repos_dir="${ERIC_ROOT}/repos"
+    if [[ -d "$repos_dir" ]]; then
+        find "$repos_dir" -mindepth 2 -maxdepth 2 -type d -exec test -d '{}/.git' \; -print | sort
+    fi
+}
 
 OUTPUT_FILE=""
 REPOS=()
@@ -60,11 +54,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Use default repos if none specified
+# Use discovered repos if none specified
 if [[ ${#REPOS[@]} -eq 0 ]]; then
-    for repo in "${DEFAULT_REPOS[@]}"; do
-        REPOS+=("${ERIC_ROOT}/${repo}")
-    done
+    while IFS= read -r repo; do
+        REPOS+=("$repo")
+    done < <(discover_repos)
 fi
 
 scan_repo() {


### PR DESCRIPTION
## Summary

Add local vulnerability scanning scripts for developer use.

## Changes

- `scripts/osv-scan-repos.sh` - Multi-language scanner using osv-scanner Go binary
- `scripts/pip-audit-scan-repos.sh` - Python-only scanner using uvx pip-audit (no install needed)

Both scripts:
- Scan all ERIC workspace repos by default
- Support markdown output via `-o` flag
- Include usage help via `-h` flag

## Related

Implements first two tasks from #153

## Test plan

- [x] Run `./scripts/osv-scan-repos.sh -h` - verify help output
- [x] Run `./scripts/pip-audit-scan-repos.sh -h` - verify help output  
- [x] Run `./scripts/pip-audit-scan-repos.sh` - verify scans Python repos
- [ ] Run with `-o results.md` - verify markdown output