### PR TITLE
feat: add sci-react-ui to workspace

### DIFF
--- a/claude-code/CLAUDE.md
+++ b/claude-code/CLAUDE.md
@@ -141,6 +141,16 @@ Developer tooling, documentation, and workspace configuration for the SmartEM ec
 
 **Tech**: Python 3.11+, Node.js, React 19, Vite, TypeScript
 
+### sci-react-ui
+
+**Ownership**: Full (DLS GitHub org)
+**Deliverable**: SmartEM (shared UI components)
+**Role**: Theme and component library for React applications at Diamond Light Source
+
+Provides Material UI-based components and theming for consistent UI across DLS web applications. Used by smartem-frontend. Library is actively in development - see repo README for current component list.
+
+**Tech**: React, TypeScript, Material UI, Rollup, Storybook, pnpm
+
 ---
 
 ## repos/FragmentScreen/

--- a/core/index.ts
+++ b/core/index.ts
@@ -204,6 +204,7 @@ export const searchConfig: SearchConfig = {
     { owner: 'DiamondLightSource', repo: 'smartem-frontend', label: 'smartem-frontend' },
     { owner: 'DiamondLightSource', repo: 'smartem-devtools', label: 'smartem-devtools' },
     { owner: 'DiamondLightSource', repo: 'fandanGO-cryoem-dls', label: 'fandanGO-cryoem-dls' },
+    { owner: 'DiamondLightSource', repo: 'sci-react-ui', label: 'sci-react-ui' },
   ],
   enableGithubSearch: true,
   shortcut: {

--- a/core/repos.json
+++ b/core/repos.json
@@ -108,6 +108,16 @@
           },
           "tags": ["reference", "python", "backend"],
           "ownership": "reference-only"
+        },
+        {
+          "name": "sci-react-ui",
+          "description": "Theme and component library for scientific institution websites",
+          "urls": {
+            "https": "https://github.com/DiamondLightSource/sci-react-ui.git",
+            "ssh": "git@github.com:DiamondLightSource/sci-react-ui.git"
+          },
+          "tags": ["ui", "react", "frontend", "smartem"],
+          "ownership": "full"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Add `DiamondLightSource/sci-react-ui` to the ERIC workspace
- Update `core/repos.json` with repository metadata (full ownership, frontend/react/ui/smartem tags)
- Add documentation section in `claude-code/CLAUDE.md`
- Add to `searchConfig.githubRepos` for WebUI search functionality

## Context
sci-react-ui is a Material UI theme and component library for scientific institution websites. It will be used by smartem-frontend for consistent UI theming and reusable components (Navbar, Footer, Breadcrumbs, ThemeProvider).

**Package**: `@diamondlightsource/sci-react-ui` (npm)
**Tech stack**: React, TypeScript, Material UI, Rollup, Storybook, pnpm

## Test plan
- [x] Verify repo cloned successfully to `repos/DiamondLightSource/sci-react-ui`
- [ ] CI passes (repos.json schema validation, TypeScript compilation)

## Related
Repo has already been cloned to workspace. Next step (separate task) is to integrate with smartem-frontend.