### PR TITLE
refactor: use Dockerfile.dev for local image builds

### DIFF
--- a/scripts/k8s/dev-k8s.sh
+++ b/scripts/k8s/dev-k8s.sh
@@ -362,7 +362,7 @@ ensure_local_image() {
     if ! docker image inspect "$image_name" &> /dev/null; then
         log_info "Building SmartEM image..."
         cd "$PROJECT_ROOT"
-        docker build -t "$image_name" .
+        docker build -f Dockerfile.dev -t "$image_name" .
     else
         log_info "SmartEM image already exists in Docker"
     fi


### PR DESCRIPTION
## Summary

- Update `dev-k8s.sh` to reference `Dockerfile.dev` for local source-based image builds

## Context

The smartem-decisions repo renamed its source-based Dockerfile to `Dockerfile.dev` as part of the Docker-from-PyPI rework. This companion change ensures `ensure_local_image()` in `dev-k8s.sh` points to the renamed file.

## Companion PR

- DiamondLightSource/smartem-decisions#229

## Related

Part of DiamondLightSource/smartem-decisions#212