### PR TITLE
docs: add k3s kubeconfig permissions note to devops skill

### DIFF
--- a/claude-code/shared/skills/devops/SKILL.md
+++ b/claude-code/shared/skills/devops/SKILL.md
@@ -21,6 +21,24 @@ Kubernetes deployment, container management, and CI/CD operations for the SmartE
 
 ### Local Development Cluster
 
+**Known issue: k3s kubeconfig permissions**
+
+k3s is installed with tight permissions on the kubeconfig file. After every system reboot, `kubectl` commands will fail with:
+
+```
+error: error loading config file "/etc/rancher/k3s/k3s.yaml": permission denied
+```
+
+Fix by running (requires sudo):
+
+```bash
+sudo chmod 644 /etc/rancher/k3s/k3s.yaml
+```
+
+If you encounter this error, advise the user to run the above command. Other permission-related issues may also surface with k3s (e.g. node token permissions, containerd socket access). These are typically resolved with similar `chmod` or group membership adjustments after reboot.
+
+**Cluster management:**
+
 ```bash
 cd repos/DiamondLightSource/smartem-decisions
 


### PR DESCRIPTION
## Summary

- Add known issue note to the devops skill about k3s kubeconfig permissions reverting after system reboot
- Document the fix (`sudo chmod 644 /etc/rancher/k3s/k3s.yaml`) and general permission gotchas

## Context

k3s installs with restrictive permissions on `/etc/rancher/k3s/k3s.yaml`. After every reboot, `kubectl` fails with permission denied. This was encountered during local cluster operations and should be documented so Claude Code can recognise the problem and advise the fix.

## Test plan

- [x] Skill file renders correctly in Claude Code
- [x] Pre-push hooks pass