### PR TITLE
Add Chrome DevTools MCP and generalize MCP setup

### DIFF
--- a/core/claude-code-config.json
+++ b/core/claude-code-config.json
@@ -18,7 +18,8 @@
         "Bash(ls:*)",
         "Bash(cat:*)",
         "WebSearch",
-        "mcp__serena__*"
+        "mcp__serena__*",
+        "mcp__chrome-devtools__*"
       ]
     }
   },
@@ -40,6 +41,12 @@
         "ide-assistant",
         "--project",
         "${PWD}"
+      ]
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@latest"
       ]
     }
   }

--- a/packages/smartem-workspace/pyproject.toml
+++ b/packages/smartem-workspace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smartem-workspace"
-version = "0.5.0"
+version = "0.6.0"
 description = "CLI tool to automate SmartEM multi-repo workspace setup"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/smartem-workspace/smartem_workspace/__init__.py
+++ b/packages/smartem-workspace/smartem_workspace/__init__.py
@@ -1,3 +1,3 @@
 """SmartEM workspace setup CLI tool."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/packages/smartem-workspace/smartem_workspace/commands/check.py
+++ b/packages/smartem-workspace/smartem_workspace/commands/check.py
@@ -322,7 +322,9 @@ def run_serena_checks(workspace_path: Path, claude_config: ClaudeCodeConfig | No
                         )
                     )
                 else:
-                    results.append(CheckResult(".mcp.json servers", "ok", f"{len(defined_servers)} server(s) configured"))
+                    results.append(
+                        CheckResult(".mcp.json servers", "ok", f"{len(defined_servers)} server(s) configured")
+                    )
             except (json.JSONDecodeError, KeyError):
                 pass
     else:

--- a/packages/smartem-workspace/smartem_workspace/commands/check.py
+++ b/packages/smartem-workspace/smartem_workspace/commands/check.py
@@ -290,7 +290,7 @@ def run_claude_checks(workspace_path: Path, claude_config: ClaudeCodeConfig) -> 
     return CheckReport("claude", results)
 
 
-def run_serena_checks(workspace_path: Path) -> CheckReport:
+def run_serena_checks(workspace_path: Path, claude_config: ClaudeCodeConfig | None = None) -> CheckReport:
     results = []
 
     serena_dir = workspace_path / ".serena"
@@ -305,6 +305,26 @@ def run_serena_checks(workspace_path: Path) -> CheckReport:
     mcp_json = workspace_path / ".mcp.json"
     if mcp_json.exists():
         results.append(check_json_valid(mcp_json, ".mcp.json"))
+
+        if claude_config:
+            try:
+                mcp_data = json.loads(mcp_json.read_text())
+                defined_servers = set(mcp_data.get("mcpServers", {}).keys())
+                expected_servers = set(claude_config.mcpConfig.model_dump().keys())
+                missing = expected_servers - defined_servers
+                if missing:
+                    results.append(
+                        CheckResult(
+                            ".mcp.json servers",
+                            "warning",
+                            f"Missing servers: {', '.join(sorted(missing))}. Re-run setup to add them.",
+                            fixable=False,
+                        )
+                    )
+                else:
+                    results.append(CheckResult(".mcp.json servers", "ok", f"{len(defined_servers)} server(s) configured"))
+            except (json.JSONDecodeError, KeyError):
+                pass
     else:
         results.append(CheckResult(".mcp.json", "warning", "Missing", fixable=False))
 
@@ -357,7 +377,7 @@ def run_checks(
         reports.append(run_claude_checks(workspace_path, claude_config))
 
     if scope in (CheckScope.ALL, CheckScope.SERENA) and workspace_path:
-        reports.append(run_serena_checks(workspace_path))
+        reports.append(run_serena_checks(workspace_path, claude_config))
 
     if scope in (CheckScope.ALL, CheckScope.REPOS) and workspace_path and config:
         reports.append(run_repos_checks(workspace_path, config))

--- a/packages/smartem-workspace/smartem_workspace/config/claude-code-config.json
+++ b/packages/smartem-workspace/smartem_workspace/config/claude-code-config.json
@@ -4,11 +4,13 @@
   "description": "Claude Code integration configuration for SmartEM workspace",
   "claudeConfig": {
     "skills": [
-      { "name": "database", "path": "claude-code/shared/skills/database" },
+      { "name": "database-admin", "path": "claude-code/shared/skills/database-admin" },
       { "name": "devops", "path": "claude-code/shared/skills/devops" },
-      { "name": "tech-writer", "path": "claude-code/shared/skills/tech-writer" },
+      { "name": "technical-writer", "path": "claude-code/shared/skills/technical-writer" },
       { "name": "git", "path": "claude-code/shared/skills/git" },
-      { "name": "playwright", "path": "claude-code/smartem-frontend/skills/playwright" }
+      { "name": "github", "path": "claude-code/shared/skills/github" },
+      { "name": "ascii-art", "path": "claude-code/shared/skills/ascii-art" },
+      { "name": "playwright-skill", "path": "claude-code/smartem-frontend/skills/playwright-skill" }
     ],
     "defaultPermissions": {
       "allow": [
@@ -16,7 +18,8 @@
         "Bash(ls:*)",
         "Bash(cat:*)",
         "WebSearch",
-        "mcp__serena__*"
+        "mcp__serena__*",
+        "mcp__chrome-devtools__*"
       ]
     }
   },
@@ -38,6 +41,12 @@
         "ide-assistant",
         "--project",
         "${PWD}"
+      ]
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@latest"
       ]
     }
   }

--- a/packages/smartem-workspace/smartem_workspace/config/schema.py
+++ b/packages/smartem-workspace/smartem_workspace/config/schema.py
@@ -93,7 +93,13 @@ class McpServerConfig(BaseModel):
 
 
 class McpConfig(BaseModel):
-    """MCP servers configuration."""
+    """MCP servers configuration.
+
+    Serena is required; additional servers (e.g. chrome-devtools) are accepted
+    via extra="allow" so the schema doesn't need updating for each new server.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     serena: McpServerConfig
 

--- a/packages/smartem-workspace/smartem_workspace/setup/bootstrap.py
+++ b/packages/smartem-workspace/smartem_workspace/setup/bootstrap.py
@@ -13,7 +13,7 @@ from smartem_workspace.interactive.prompts import (
 )
 from smartem_workspace.setup.claude import setup_claude_config
 from smartem_workspace.setup.repos import clone_repos
-from smartem_workspace.setup.serena import setup_serena_config
+from smartem_workspace.setup.mcp import setup_mcp_config
 from smartem_workspace.setup.workspace import display_next_steps, setup_workspace_structure
 
 console = Console()
@@ -113,9 +113,9 @@ def bootstrap_workspace(
     if not skip_claude and claude_config:
         setup_claude_config(claude_config, workspace_path)
 
-    if not skip_serena:
+    if not skip_serena and claude_config:
         project_name = workspace_path.name or "smartem-workspace"
-        setup_serena_config(config, workspace_path, project_name)
+        setup_mcp_config(claude_config, workspace_path, project_name)
 
     display_next_steps(workspace_path)
 

--- a/packages/smartem-workspace/smartem_workspace/setup/bootstrap.py
+++ b/packages/smartem-workspace/smartem_workspace/setup/bootstrap.py
@@ -12,8 +12,8 @@ from smartem_workspace.interactive.prompts import (
     select_repos,
 )
 from smartem_workspace.setup.claude import setup_claude_config
-from smartem_workspace.setup.repos import clone_repos
 from smartem_workspace.setup.mcp import setup_mcp_config
+from smartem_workspace.setup.repos import clone_repos
 from smartem_workspace.setup.workspace import display_next_steps, setup_workspace_structure
 
 console = Console()

--- a/packages/smartem-workspace/smartem_workspace/setup/claude.py
+++ b/packages/smartem-workspace/smartem_workspace/setup/claude.py
@@ -73,6 +73,7 @@ def setup_claude_config(
     if not settings_path.exists():
         settings = {
             "permissions": config.claudeConfig.defaultPermissions.model_dump(),
+            "enabledMcpjsonServers": ["serena"],
         }
         settings_path.write_text(json.dumps(settings, indent=2))
         console.print(f"  [green]Created {settings_path.name}[/green]")

--- a/packages/smartem-workspace/smartem_workspace/setup/mcp.py
+++ b/packages/smartem-workspace/smartem_workspace/setup/mcp.py
@@ -1,4 +1,4 @@
-"""Serena MCP server configuration setup."""
+"""MCP server configuration setup."""
 
 import json
 from pathlib import Path
@@ -6,28 +6,28 @@ from pathlib import Path
 import yaml
 from rich.console import Console
 
-from smartem_workspace.config.schema import ReposConfig
+from smartem_workspace.config.schema import ClaudeCodeConfig, McpServerConfig
 
 console = Console()
 
 
-def setup_serena_config(
-    config: ReposConfig,
+def setup_mcp_config(
+    config: ClaudeCodeConfig,
     workspace_path: Path,
     project_name: str = "smartem-workspace",
 ) -> bool:
     """
-    Set up Serena MCP server configuration.
+    Set up MCP server configuration.
 
     Creates:
-    - .serena/project.yml
-    - .mcp.json
+    - .serena/project.yml (Serena-specific config)
+    - .mcp.json (all MCP servers from config)
 
     Returns:
         True if successful
     """
     console.print()
-    console.print("[bold]Setting up Serena MCP configuration...[/bold]")
+    console.print("[bold]Setting up MCP configuration...[/bold]")
 
     serena_dir = workspace_path / ".serena"
     serena_dir.mkdir(parents=True, exist_ok=True)
@@ -50,19 +50,19 @@ def setup_serena_config(
 
     mcp_json_path = workspace_path / ".mcp.json"
     if not mcp_json_path.exists():
-        mcp_config = {
-            "mcpServers": {
-                "serena": {
-                    "command": config.mcpConfig.serena.command,
-                    "args": [arg.replace("${PWD}", str(workspace_path)) for arg in config.mcpConfig.serena.args],
-                }
+        mcp_servers = {}
+        for name, server_config in config.mcpConfig.model_dump().items():
+            if not isinstance(server_config, dict) or "command" not in server_config:
+                continue
+            mcp_servers[name] = {
+                "command": server_config["command"],
+                "args": [arg.replace("${PWD}", str(workspace_path)) for arg in server_config.get("args", [])],
             }
-        }
 
-        mcp_json_path.write_text(json.dumps(mcp_config, indent=2))
-        console.print(f"  [green]Created {mcp_json_path.name}[/green]")
+        mcp_json_path.write_text(json.dumps({"mcpServers": mcp_servers}, indent=2))
+        console.print(f"  [green]Created {mcp_json_path.name} ({len(mcp_servers)} servers)[/green]")
     else:
         console.print(f"  [dim]{mcp_json_path.name} already exists[/dim]")
 
-    console.print("[green]Serena configuration complete[/green]")
+    console.print("[green]MCP configuration complete[/green]")
     return True

--- a/packages/smartem-workspace/smartem_workspace/setup/mcp.py
+++ b/packages/smartem-workspace/smartem_workspace/setup/mcp.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import yaml
 from rich.console import Console
 
-from smartem_workspace.config.schema import ClaudeCodeConfig, McpServerConfig
+from smartem_workspace.config.schema import ClaudeCodeConfig
 
 console = Console()
 

--- a/packages/smartem-workspace/uv.lock
+++ b/packages/smartem-workspace/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "smartem-workspace"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Add Chrome DevTools MCP server (`chrome-devtools-mcp`) for browser debugging during frontend development
- Generalize MCP setup to support multiple servers from config instead of hardcoding only Serena
- Chrome DevTools is **opt-in** -- defined in `.mcp.json` but not in `enabledMcpjsonServers` by default, avoiding unnecessary token usage for non-frontend developers

## Implementation details

### Config changes
- `core/claude-code-config.json`: add `chrome-devtools` entry to `mcpConfig` and `mcp__chrome-devtools__*` to default permissions
- Bundled copy synced to `packages/smartem-workspace/smartem_workspace/config/`

### Schema
- `McpConfig` now uses `extra="allow"` so new MCP servers can be added to config JSON without schema changes each time. `serena` remains the only required server.

### MCP setup generalization
- **Renamed** `setup/serena.py` to `setup/mcp.py` -- now responsible for all MCP servers
- `setup_mcp_config()` iterates all servers in `mcpConfig` and writes them to `.mcp.json`, replacing `${PWD}` placeholders in args
- **Bug fix**: `bootstrap.py` was passing `ReposConfig` to `setup_serena_config` but the function accessed `mcpConfig`/`serenaConfig` which only exist on `ClaudeCodeConfig`. Now correctly passes `claude_config`.

### Opt-in mechanism
- `setup/claude.py` now writes `enabledMcpjsonServers: ["serena"]` to `settings.local.json` by default
- Frontend developers opt in by adding `"chrome-devtools"` to their local `enabledMcpjsonServers` array
- Permissions for `mcp__chrome-devtools__*` are pre-configured so no further setup needed once enabled

### Check command
- `run_serena_checks()` now accepts `claude_config` and validates that `.mcp.json` contains all expected servers from config, warning about any missing ones

### Version
- Bumped `0.5.0` -> `0.6.0`

## How to enable Chrome DevTools MCP (after release)
1. `uvx smartem-workspace check --fix` to regenerate `.mcp.json` with both servers
2. Add `"chrome-devtools"` to `enabledMcpjsonServers` in `.claude/settings.local.json`
3. Launch Chrome with `google-chrome --remote-debugging-port=9222`
4. Restart Claude Code -- chrome-devtools MCP tools become available

## Release steps (for maintainer)
1. Merge this PR
2. Verify version `0.6.0` in both `pyproject.toml` and `__init__.py`
3. Tag: `git tag smartem-workspace-v0.6.0`
4. Push: `git push origin main --tags`
5. GitHub Actions publishes to PyPI

## Test plan
- [x] All 16 existing tests pass
- [x] Schema correctly parses config with both MCP servers
- [x] Import chain verified: `setup.mcp`, `setup.bootstrap`, `commands.check`
- [ ] `smartem-workspace check` reports missing servers if `.mcp.json` is stale
- [ ] `smartem-workspace init --with-claude` creates `.mcp.json` with both servers
- [ ] Chrome DevTools MCP loads in Claude Code when enabled and Chrome is running with `--remote-debugging-port=9222`