### PR TITLE
fix: sync claude-code-config with renamed skills + clean stale symlinks

### DIFF
--- a/core/claude-code-config.json
+++ b/core/claude-code-config.json
@@ -4,13 +4,11 @@
   "description": "Claude Code integration configuration for SmartEM workspace",
   "claudeConfig": {
     "skills": [
-      { "name": "database-admin", "path": "claude-code/shared/skills/database-admin" },
+      { "name": "database", "path": "claude-code/shared/skills/database" },
       { "name": "devops", "path": "claude-code/shared/skills/devops" },
-      { "name": "technical-writer", "path": "claude-code/shared/skills/technical-writer" },
+      { "name": "tech-writer", "path": "claude-code/shared/skills/tech-writer" },
       { "name": "git", "path": "claude-code/shared/skills/git" },
-      { "name": "github", "path": "claude-code/shared/skills/github" },
-      { "name": "ascii-art", "path": "claude-code/shared/skills/ascii-art" },
-      { "name": "playwright-skill", "path": "claude-code/smartem-frontend/skills/playwright-skill" }
+      { "name": "playwright", "path": "claude-code/smartem-frontend/skills/playwright" }
     ],
     "defaultPermissions": {
       "allow": [

--- a/packages/smartem-workspace/pyproject.toml
+++ b/packages/smartem-workspace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smartem-workspace"
-version = "0.6.0"
+version = "0.6.1"
 description = "CLI tool to automate SmartEM multi-repo workspace setup"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/smartem-workspace/smartem_workspace/__init__.py
+++ b/packages/smartem-workspace/smartem_workspace/__init__.py
@@ -1,3 +1,3 @@
 """SmartEM workspace setup CLI tool."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/packages/smartem-workspace/smartem_workspace/commands/check.py
+++ b/packages/smartem-workspace/smartem_workspace/commands/check.py
@@ -276,10 +276,26 @@ def run_claude_checks(workspace_path: Path, claude_config: ClaudeCodeConfig) -> 
     else:
         results.append(CheckResult(".claude/skills directory", "ok", "Present"))
 
+    expected_skill_names = {skill.name for skill in claude_config.claudeConfig.skills}
     for skill in claude_config.claudeConfig.skills:
         skill_link = skills_dir / skill.name
         skill_target = devtools_path / skill.path
         results.append(check_symlink(skill_link, skill_target, f"skill: {skill.name}"))
+
+    if skills_dir.exists():
+        for entry in skills_dir.iterdir():
+            if entry.name in expected_skill_names:
+                continue
+            if entry.is_symlink() and not entry.exists():
+                results.append(
+                    CheckResult(
+                        f"skill: {entry.name}",
+                        "warning",
+                        "Broken symlink (stale)",
+                        fixable=True,
+                        fix_data={"remove_broken_symlink": str(entry)},
+                    )
+                )
 
     settings_path = workspace_path / ".claude" / "settings.local.json"
     if settings_path.exists():
@@ -405,6 +421,20 @@ def apply_fixes(workspace_path: Path, reports: list[CheckReport]) -> tuple[int, 
                     fixed += 1
                 except OSError as e:
                     console.print(f"  [red]Failed to create directory: {e}[/red]")
+                    failed += 1
+
+            elif "remove_broken_symlink" in fix_data:
+                broken_path = Path(fix_data["remove_broken_symlink"])
+                try:
+                    if broken_path.is_symlink() and not broken_path.exists():
+                        broken_path.unlink()
+                        console.print(f"  [green]Removed broken symlink: {broken_path.name}[/green]")
+                        fixed += 1
+                    else:
+                        console.print(f"  [yellow]Skipped (no longer broken): {broken_path.name}[/yellow]")
+                        failed += 1
+                except OSError as e:
+                    console.print(f"  [red]Failed to remove broken symlink: {e}[/red]")
                     failed += 1
 
             elif "link" in fix_data and "target" in fix_data:

--- a/packages/smartem-workspace/smartem_workspace/config/claude-code-config.json
+++ b/packages/smartem-workspace/smartem_workspace/config/claude-code-config.json
@@ -4,13 +4,11 @@
   "description": "Claude Code integration configuration for SmartEM workspace",
   "claudeConfig": {
     "skills": [
-      { "name": "database-admin", "path": "claude-code/shared/skills/database-admin" },
+      { "name": "database", "path": "claude-code/shared/skills/database" },
       { "name": "devops", "path": "claude-code/shared/skills/devops" },
-      { "name": "technical-writer", "path": "claude-code/shared/skills/technical-writer" },
+      { "name": "tech-writer", "path": "claude-code/shared/skills/tech-writer" },
       { "name": "git", "path": "claude-code/shared/skills/git" },
-      { "name": "github", "path": "claude-code/shared/skills/github" },
-      { "name": "ascii-art", "path": "claude-code/shared/skills/ascii-art" },
-      { "name": "playwright-skill", "path": "claude-code/smartem-frontend/skills/playwright-skill" }
+      { "name": "playwright", "path": "claude-code/smartem-frontend/skills/playwright" }
     ],
     "defaultPermissions": {
       "allow": [

--- a/packages/smartem-workspace/uv.lock
+++ b/packages/smartem-workspace/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "smartem-workspace"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Two related fixes surfaced while running `uvx smartem-workspace check --fix`:

1. **Config was stale after commit 151c4fe** which renamed and removed several skills but never updated `core/claude-code-config.json` (nor the bundled copy shipped with `smartem-workspace`).
2. **No cleanup for broken symlinks** — the check tool created symlinks but never removed stale ones when config evolved.

## Config changes

| Before | After |
|---|---|
| `database-admin` | `database` (renamed) |
| `technical-writer` | `tech-writer` (renamed) |
| `playwright-skill` | `playwright` (renamed) |
| `github` | removed (merged into `git`) |
| `ascii-art` | removed (deleted in 151c4fe) |

Both `core/claude-code-config.json` (served via GitHub raw, network-first) and the bundled fallback at `packages/smartem-workspace/smartem_workspace/config/claude-code-config.json` are synced.

## check.py enhancement

Adds detection + fix for stale broken symlinks in `.claude/skills/`. Three safety constraints ensure we never clobber user-created skills:

1. Must be a symlink (`is_symlink()`)
2. Target must not exist (`not entry.exists()` — follows symlinks, returns False when broken)
3. Name must not be in the expected skills list (avoids double-handling of known skills)

Regular files, regular dirs, and valid symlinks (regardless of target) are left alone.

## Version bump

`smartem-workspace` 0.6.0 -> 0.6.1 so the check.py improvement reaches PyPI users.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pytest -q` — 16 tests pass
- [x] Manually verified current workspace `.claude/skills/` contains only valid symlinks (no regression)
- [ ] After merge: tag `smartem-workspace-v0.6.1` to trigger PyPI publish
- [ ] After release: re-run `uvx smartem-workspace check --fix` on a workspace with stale symlinks to verify cleanup behavior end-to-end