### PR TITLE
chore: sync smartem-decisions OpenAPI spec to latest main

### DIFF
--- a/docs/api/smartem/swagger.json
+++ b/docs/api/smartem/swagger.json
@@ -1,1842 +1,8 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "SmartEM Decisions Backend API",
-    "description": "API for accessing and managing electron microscopy data",
-    "version": "0.1.dev276+g1b7ed28d6.d20250818"
-  },
-  "paths": {
-    "/status": {
-      "get": {
-        "summary": "Get Status",
-        "description": "Get API status and configuration information",
-        "operationId": "get_status_status_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/health": {
-      "get": {
-        "summary": "Get Health",
-        "description": "Health check endpoint with actual connectivity checks",
-        "operationId": "get_health_health_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/acquisitions": {
-      "get": {
-        "summary": "Get Acquisitions",
-        "description": "Get all acquisitions",
-        "operationId": "get_acquisitions_acquisitions_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AcquisitionResponse"
-                  },
-                  "type": "array",
-                  "title": "Response Get Acquisitions Acquisitions Get"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Create Acquisition",
-        "description": "Create a new acquisition",
-        "operationId": "create_acquisition_acquisitions_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AcquisitionCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcquisitionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/acquisitions/{acquisition_uuid}": {
-      "get": {
-        "summary": "Get Acquisition",
-        "description": "Get a single acquisition by ID",
-        "operationId": "get_acquisition_acquisitions__acquisition_uuid__get",
-        "parameters": [
-          {
-            "name": "acquisition_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Acquisition Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcquisitionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Update Acquisition",
-        "description": "Update an acquisition",
-        "operationId": "update_acquisition_acquisitions__acquisition_uuid__put",
-        "parameters": [
-          {
-            "name": "acquisition_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Acquisition Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AcquisitionUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcquisitionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Acquisition",
-        "description": "Delete an acquisition",
-        "operationId": "delete_acquisition_acquisitions__acquisition_uuid__delete",
-        "parameters": [
-          {
-            "name": "acquisition_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Acquisition Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/grids": {
-      "get": {
-        "summary": "Get Grids",
-        "description": "Get all grids",
-        "operationId": "get_grids_grids_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GridResponse"
-                  },
-                  "type": "array",
-                  "title": "Response Get Grids Grids Get"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/grids/{grid_uuid}": {
-      "get": {
-        "summary": "Get Grid",
-        "description": "Get a single grid by ID",
-        "operationId": "get_grid_grids__grid_uuid__get",
-        "parameters": [
-          {
-            "name": "grid_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Grid Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Update Grid",
-        "description": "Update a grid",
-        "operationId": "update_grid_grids__grid_uuid__put",
-        "parameters": [
-          {
-            "name": "grid_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Grid Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Grid",
-        "description": "Delete a grid by publishing to RabbitMQ",
-        "operationId": "delete_grid_grids__grid_uuid__delete",
-        "parameters": [
-          {
-            "name": "grid_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Grid Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/acquisitions/{acquisition_uuid}/grids": {
-      "get": {
-        "summary": "Get Acquisition Grids",
-        "description": "Get all grids for a specific acquisition",
-        "operationId": "get_acquisition_grids_acquisitions__acquisition_uuid__grids_get",
-        "parameters": [
-          {
-            "name": "acquisition_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Acquisition Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/GridResponse"
-                  },
-                  "title": "Response Get Acquisition Grids Acquisitions  Acquisition Uuid  Grids Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Create Acquisition Grid",
-        "description": "Create a new grid for a specific acquisition",
-        "operationId": "create_acquisition_grid_acquisitions__acquisition_uuid__grids_post",
-        "parameters": [
-          {
-            "name": "acquisition_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Acquisition Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/grids/{grid_uuid}/registered": {
-      "post": {
-        "summary": "Grid Registered",
-        "description": "All squares on a grid have been registered at low mag",
-        "operationId": "grid_registered_grids__grid_uuid__registered_post",
-        "parameters": [
-          {
-            "name": "grid_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Grid Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean",
-                  "title": "Response Grid Registered Grids  Grid Uuid  Registered Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/atlases": {
-      "get": {
-        "summary": "Get Atlases",
-        "description": "Get all atlases",
-        "operationId": "get_atlases_atlases_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AtlasResponse"
-                  },
-                  "type": "array",
-                  "title": "Response Get Atlases Atlases Get"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/atlases/{atlas_uuid}": {
-      "get": {
-        "summary": "Get Atlas",
-        "description": "Get a single atlas by ID",
-        "operationId": "get_atlas_atlases__atlas_uuid__get",
-        "parameters": [
-          {
-            "name": "atlas_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Atlas Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Update Atlas",
-        "description": "Update an atlas",
-        "operationId": "update_atlas_atlases__atlas_uuid__put",
-        "parameters": [
-          {
-            "name": "atlas_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Atlas Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AtlasUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Atlas",
-        "description": "Delete an atlas by publishing to RabbitMQ",
-        "operationId": "delete_atlas_atlases__atlas_uuid__delete",
-        "parameters": [
-          {
-            "name": "atlas_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Atlas Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/grids/{grid_uuid}/atlas": {
-      "get": {
-        "summary": "Get Grid Atlas",
-        "description": "Get the atlas for a specific grid",
-        "operationId": "get_grid_atlas_grids__grid_uuid__atlas_get",
-        "parameters": [
-          {
-            "name": "grid_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Grid Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Create Grid Atlas",
-        "description": "Create a new atlas for a grid",
-        "operationId": "create_grid_atlas_grids__grid_uuid__atlas_post",
-        "parameters": [
-          {
-            "name": "grid_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Grid Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AtlasCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/atlas-tiles": {
-      "get": {
-        "summary": "Get Atlas Tiles",
-        "description": "Get all atlas tiles",
-        "operationId": "get_atlas_tiles_atlas_tiles_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AtlasTileResponse"
-                  },
-                  "type": "array",
-                  "title": "Response Get Atlas Tiles Atlas Tiles Get"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/atlas-tiles/{tile_uuid}": {
-      "get": {
-        "summary": "Get Atlas Tile",
-        "description": "Get a single atlas tile by ID",
-        "operationId": "get_atlas_tile_atlas_tiles__tile_uuid__get",
-        "parameters": [
-          {
-            "name": "tile_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Tile Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasTileResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Update Atlas Tile",
-        "description": "Update an atlas tile",
-        "operationId": "update_atlas_tile_atlas_tiles__tile_uuid__put",
-        "parameters": [
-          {
-            "name": "tile_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Tile Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AtlasTileUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasTileResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Atlas Tile",
-        "description": "Delete an atlas tile by publishing to RabbitMQ",
-        "operationId": "delete_atlas_tile_atlas_tiles__tile_uuid__delete",
-        "parameters": [
-          {
-            "name": "tile_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Tile Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/atlases/{atlas_uuid}/tiles": {
-      "get": {
-        "summary": "Get Atlas Tiles By Atlas",
-        "description": "Get all tiles for a specific atlas",
-        "operationId": "get_atlas_tiles_by_atlas_atlases__atlas_uuid__tiles_get",
-        "parameters": [
-          {
-            "name": "atlas_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Atlas Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AtlasTileResponse"
-                  },
-                  "title": "Response Get Atlas Tiles By Atlas Atlases  Atlas Uuid  Tiles Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Create Atlas Tile For Atlas",
-        "description": "Create a new tile for a specific atlas",
-        "operationId": "create_atlas_tile_for_atlas_atlases__atlas_uuid__tiles_post",
-        "parameters": [
-          {
-            "name": "atlas_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Atlas Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AtlasTileCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasTileResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/atlas-tiles/{tile_uuid}/gridsquares/{gridsquare_uuid}": {
-      "post": {
-        "summary": "Link Atlas Tile To Gridsquare",
-        "description": "Connect a grid square to a tile with its position information",
-        "operationId": "link_atlas_tile_to_gridsquare_atlas_tiles__tile_uuid__gridsquares__gridsquare_uuid__post",
-        "parameters": [
-          {
-            "name": "tile_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Tile Uuid"
-            }
-          },
-          {
-            "name": "gridsquare_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Gridsquare Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridSquarePositionRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/gridsquares": {
-      "get": {
-        "summary": "Get Gridsquares",
-        "description": "Get all grid squares",
-        "operationId": "get_gridsquares_gridsquares_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GridSquareResponse"
-                  },
-                  "type": "array",
-                  "title": "Response Get Gridsquares Gridsquares Get"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/gridsquares/{gridsquare_uuid}": {
-      "get": {
-        "summary": "Get Gridsquare",
-        "description": "Get a single grid square by ID",
-        "operationId": "get_gridsquare_gridsquares__gridsquare_uuid__get",
-        "parameters": [
-          {
-            "name": "gridsquare_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Gridsquare Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridSquareResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Update Gridsquare",
-        "description": "Update a grid square",
-        "operationId": "update_gridsquare_gridsquares__gridsquare_uuid__put",
-        "parameters": [
-          {
-            "name": "gridsquare_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Gridsquare Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridSquareUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridSquareResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Gridsquare",
-        "description": "Delete a grid square by publishing to RabbitMQ",
-        "operationId": "delete_gridsquare_gridsquares__gridsquare_uuid__delete",
-        "parameters": [
-          {
-            "name": "gridsquare_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Gridsquare Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/grids/{grid_uuid}/gridsquares": {
-      "get": {
-        "summary": "Get Grid Gridsquares",
-        "description": "Get all grid squares for a specific grid",
-        "operationId": "get_grid_gridsquares_grids__grid_uuid__gridsquares_get",
-        "parameters": [
-          {
-            "name": "grid_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Grid Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/GridSquareResponse"
-                  },
-                  "title": "Response Get Grid Gridsquares Grids  Grid Uuid  Gridsquares Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Create Grid Gridsquare",
-        "description": "Create a new grid square for a specific grid",
-        "operationId": "create_grid_gridsquare_grids__grid_uuid__gridsquares_post",
-        "parameters": [
-          {
-            "name": "grid_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Grid Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridSquareCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridSquareResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/gridsquares/{gridsquare_uuid}/registered": {
-      "post": {
-        "summary": "Gridsquare Registered",
-        "description": "All holes on a grid square have been registered at square mag",
-        "operationId": "gridsquare_registered_gridsquares__gridsquare_uuid__registered_post",
-        "parameters": [
-          {
-            "name": "gridsquare_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Gridsquare Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean",
-                  "title": "Response Gridsquare Registered Gridsquares  Gridsquare Uuid  Registered Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/foilholes": {
-      "get": {
-        "summary": "Get Foilholes",
-        "description": "Get all foil holes",
-        "operationId": "get_foilholes_foilholes_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/FoilHoleResponse"
-                  },
-                  "type": "array",
-                  "title": "Response Get Foilholes Foilholes Get"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/foilholes/{foilhole_uuid}": {
-      "get": {
-        "summary": "Get Foilhole",
-        "description": "Get a single foil hole by ID",
-        "operationId": "get_foilhole_foilholes__foilhole_uuid__get",
-        "parameters": [
-          {
-            "name": "foilhole_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Foilhole Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FoilHoleResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Update Foilhole",
-        "description": "Update a foil hole",
-        "operationId": "update_foilhole_foilholes__foilhole_uuid__put",
-        "parameters": [
-          {
-            "name": "foilhole_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Foilhole Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FoilHoleUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FoilHoleResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Foilhole",
-        "description": "Delete a foil hole by publishing to RabbitMQ",
-        "operationId": "delete_foilhole_foilholes__foilhole_uuid__delete",
-        "parameters": [
-          {
-            "name": "foilhole_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Foilhole Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/gridsquares/{gridsquare_uuid}/foilholes": {
-      "get": {
-        "summary": "Get Gridsquare Foilholes",
-        "description": "Get all foil holes for a specific grid square",
-        "operationId": "get_gridsquare_foilholes_gridsquares__gridsquare_uuid__foilholes_get",
-        "parameters": [
-          {
-            "name": "gridsquare_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Gridsquare Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FoilHoleResponse"
-                  },
-                  "title": "Response Get Gridsquare Foilholes Gridsquares  Gridsquare Uuid  Foilholes Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Create Gridsquare Foilhole",
-        "description": "Create a new foil hole for a specific grid square",
-        "operationId": "create_gridsquare_foilhole_gridsquares__gridsquare_uuid__foilholes_post",
-        "parameters": [
-          {
-            "name": "gridsquare_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Gridsquare Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FoilHoleCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FoilHoleResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/micrographs": {
-      "get": {
-        "summary": "Get Micrographs",
-        "description": "Get all micrographs",
-        "operationId": "get_micrographs_micrographs_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/MicrographResponse"
-                  },
-                  "type": "array",
-                  "title": "Response Get Micrographs Micrographs Get"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/micrographs/{micrograph_uuid}": {
-      "get": {
-        "summary": "Get Micrograph",
-        "description": "Get a single micrograph by ID",
-        "operationId": "get_micrograph_micrographs__micrograph_uuid__get",
-        "parameters": [
-          {
-            "name": "micrograph_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Micrograph Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MicrographResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Update Micrograph",
-        "description": "Update a micrograph",
-        "operationId": "update_micrograph_micrographs__micrograph_uuid__put",
-        "parameters": [
-          {
-            "name": "micrograph_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Micrograph Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MicrographUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MicrographResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Micrograph",
-        "description": "Delete a micrograph by publishing to RabbitMQ",
-        "operationId": "delete_micrograph_micrographs__micrograph_uuid__delete",
-        "parameters": [
-          {
-            "name": "micrograph_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Micrograph Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/foilholes/{foilhole_uuid}/micrographs": {
-      "get": {
-        "summary": "Get Foilhole Micrographs",
-        "description": "Get all micrographs for a specific foil hole",
-        "operationId": "get_foilhole_micrographs_foilholes__foilhole_uuid__micrographs_get",
-        "parameters": [
-          {
-            "name": "foilhole_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Foilhole Uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/MicrographResponse"
-                  },
-                  "title": "Response Get Foilhole Micrographs Foilholes  Foilhole Uuid  Micrographs Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Create Foilhole Micrograph",
-        "description": "Create a new micrograph for a specific foil hole",
-        "operationId": "create_foilhole_micrograph_foilholes__foilhole_uuid__micrographs_post",
-        "parameters": [
-          {
-            "name": "foilhole_uuid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Foilhole Uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MicrographCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MicrographResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
   "components": {
     "schemas": {
       "AcquisitionCreateRequest": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/AcquisitionStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "start_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Start Time"
-          },
-          "end_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "End Time"
-          },
-          "paused_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Paused Time"
-          },
-          "storage_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Storage Path"
-          },
           "atlas_path": {
             "anyOf": [
               {
@@ -1870,7 +36,7 @@
             ],
             "title": "Clustering Radius"
           },
-          "instrument_model": {
+          "computer_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -1879,7 +45,19 @@
                 "type": "null"
               }
             ],
-            "title": "Instrument Model"
+            "title": "Computer Name"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
           },
           "instrument_id": {
             "anyOf": [
@@ -1892,7 +70,7 @@
             ],
             "title": "Instrument Id"
           },
-          "computer_name": {
+          "instrument_model": {
             "anyOf": [
               {
                 "type": "string"
@@ -1901,82 +79,77 @@
                 "type": "null"
               }
             ],
-            "title": "Computer Name"
+            "title": "Instrument Model"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "paused_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Time"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AcquisitionStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "storage_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Path"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid"
         ],
-        "title": "AcquisitionCreateRequest"
+        "title": "AcquisitionCreateRequest",
+        "type": "object"
       },
       "AcquisitionResponse": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/AcquisitionStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "start_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Start Time"
-          },
-          "end_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "End Time"
-          },
-          "paused_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Paused Time"
-          },
-          "storage_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Storage Path"
-          },
           "atlas_path": {
             "anyOf": [
               {
@@ -2010,7 +183,7 @@
             ],
             "title": "Clustering Radius"
           },
-          "instrument_model": {
+          "computer_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -2019,7 +192,19 @@
                 "type": "null"
               }
             ],
-            "title": "Instrument Model"
+            "title": "Computer Name"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
           },
           "instrument_id": {
             "anyOf": [
@@ -2032,7 +217,7 @@
             ],
             "title": "Instrument Id"
           },
-          "computer_name": {
+          "instrument_model": {
             "anyOf": [
               {
                 "type": "string"
@@ -2041,10 +226,62 @@
                 "type": "null"
               }
             ],
-            "title": "Computer Name"
+            "title": "Instrument Model"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "paused_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Time"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AcquisitionStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "storage_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Path"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "name",
@@ -2060,10 +297,10 @@
           "instrument_id",
           "computer_name"
         ],
-        "title": "AcquisitionResponse"
+        "title": "AcquisitionResponse",
+        "type": "object"
       },
       "AcquisitionStatus": {
-        "type": "string",
         "enum": [
           "planned",
           "started",
@@ -2071,89 +308,11 @@
           "paused",
           "abandoned"
         ],
-        "title": "AcquisitionStatus"
+        "title": "AcquisitionStatus",
+        "type": "string"
       },
       "AcquisitionUpdateRequest": {
         "properties": {
-          "uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uuid"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/AcquisitionStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "start_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Start Time"
-          },
-          "end_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "End Time"
-          },
-          "paused_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Paused Time"
-          },
-          "storage_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Storage Path"
-          },
           "atlas_path": {
             "anyOf": [
               {
@@ -2187,7 +346,7 @@
             ],
             "title": "Clustering Radius"
           },
-          "instrument_model": {
+          "computer_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -2196,7 +355,19 @@
                 "type": "null"
               }
             ],
-            "title": "Instrument Model"
+            "title": "Computer Name"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
           },
           "instrument_id": {
             "anyOf": [
@@ -2209,7 +380,7 @@
             ],
             "title": "Instrument Id"
           },
-          "computer_name": {
+          "instrument_model": {
             "anyOf": [
               {
                 "type": "string"
@@ -2218,17 +389,192 @@
                 "type": "null"
               }
             ],
-            "title": "Computer Name"
+            "title": "Instrument Model"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "paused_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Time"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AcquisitionStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "storage_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Path"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
           }
         },
-        "type": "object",
-        "title": "AcquisitionUpdateRequest"
+        "title": "AcquisitionUpdateRequest",
+        "type": "object"
+      },
+      "AgentInstructionAcknowledgement": {
+        "additionalProperties": false,
+        "description": "Request model for instruction acknowledgements from agents",
+        "properties": {
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "processed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processed At"
+          },
+          "processing_time_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processing Time Ms"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          },
+          "status": {
+            "enum": [
+              "received",
+              "processed",
+              "failed",
+              "declined"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "AgentInstructionAcknowledgement",
+        "type": "object"
+      },
+      "AgentInstructionAcknowledgementResponse": {
+        "description": "Response model for instruction acknowledgement confirmations",
+        "properties": {
+          "acknowledged_at": {
+            "title": "Acknowledged At",
+            "type": "string"
+          },
+          "agent_id": {
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "instruction_id": {
+            "title": "Instruction Id",
+            "type": "string"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "instruction_id",
+          "acknowledged_at",
+          "agent_id",
+          "session_id"
+        ],
+        "title": "AgentInstructionAcknowledgementResponse",
+        "type": "object"
       },
       "AtlasCreateRequest": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
+          "acquisition_date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Date"
           },
           "atlas_id": {
             "anyOf": [
@@ -2241,33 +587,6 @@
             ],
             "title": "Atlas Id"
           },
-          "grid_uuid": {
-            "type": "string",
-            "title": "Grid Uuid"
-          },
-          "acquisition_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Date"
-          },
-          "storage_folder": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Storage Folder"
-          },
           "description": {
             "anyOf": [
               {
@@ -2279,9 +598,24 @@
             ],
             "title": "Description"
           },
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
           "name": {
-            "type": "string",
-            "title": "Name"
+            "title": "Name",
+            "type": "string"
+          },
+          "storage_folder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Folder"
           },
           "tiles": {
             "anyOf": [
@@ -2296,35 +630,27 @@
               }
             ],
             "title": "Tiles"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "grid_uuid",
           "name"
         ],
-        "title": "AtlasCreateRequest"
+        "title": "AtlasCreateRequest",
+        "type": "object"
       },
       "AtlasResponse": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "grid_uuid": {
-            "type": "string",
-            "title": "Grid Uuid"
-          },
-          "atlas_id": {
-            "type": "string",
-            "title": "Atlas Id"
-          },
           "acquisition_date": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2332,16 +658,9 @@
             ],
             "title": "Acquisition Date"
           },
-          "storage_folder": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Storage Folder"
+          "atlas_id": {
+            "title": "Atlas Id",
+            "type": "string"
           },
           "description": {
             "anyOf": [
@@ -2354,9 +673,24 @@
             ],
             "title": "Description"
           },
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
           "name": {
-            "type": "string",
-            "title": "Name"
+            "title": "Name",
+            "type": "string"
+          },
+          "storage_folder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Folder"
           },
           "tiles": {
             "anyOf": [
@@ -2370,11 +704,14 @@
                 "type": "null"
               }
             ],
-            "title": "Tiles",
-            "default": []
+            "default": [],
+            "title": "Tiles"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "grid_uuid",
@@ -2384,15 +721,16 @@
           "description",
           "name"
         ],
-        "title": "AtlasResponse"
+        "title": "AtlasResponse",
+        "type": "object"
       },
       "AtlasTileCreateRequest": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
+          "atlas_uuid": {
+            "title": "Atlas Uuid",
+            "type": "string"
           },
-          "tile_id": {
+          "base_filename": {
             "anyOf": [
               {
                 "type": "string"
@@ -2401,7 +739,18 @@
                 "type": "null"
               }
             ],
-            "title": "Tile Id"
+            "title": "Base Filename"
+          },
+          "file_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Format"
           },
           "position_x": {
             "anyOf": [
@@ -2447,7 +796,7 @@
             ],
             "title": "Size Y"
           },
-          "file_format": {
+          "tile_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -2456,59 +805,47 @@
                 "type": "null"
               }
             ],
-            "title": "File Format"
+            "title": "Tile Id"
           },
-          "base_filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Base Filename"
-          },
-          "atlas_uuid": {
-            "type": "string",
-            "title": "Atlas Uuid"
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "atlas_uuid"
         ],
-        "title": "AtlasTileCreateRequest"
+        "title": "AtlasTileCreateRequest",
+        "type": "object"
       },
       "AtlasTileGridSquarePositionResponse": {
         "properties": {
           "atlastile_uuid": {
-            "type": "string",
-            "title": "Atlastile Uuid"
-          },
-          "gridsquare_uuid": {
-            "type": "string",
-            "title": "Gridsquare Uuid"
+            "title": "Atlastile Uuid",
+            "type": "string"
           },
           "center_x": {
-            "type": "integer",
-            "title": "Center X"
+            "title": "Center X",
+            "type": "integer"
           },
           "center_y": {
-            "type": "integer",
-            "title": "Center Y"
+            "title": "Center Y",
+            "type": "integer"
           },
-          "size_width": {
-            "type": "integer",
-            "title": "Size Width"
+          "gridsquare_uuid": {
+            "title": "Gridsquare Uuid",
+            "type": "string"
           },
           "size_height": {
-            "type": "integer",
-            "title": "Size Height"
+            "title": "Size Height",
+            "type": "integer"
+          },
+          "size_width": {
+            "title": "Size Width",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
           "atlastile_uuid",
           "gridsquare_uuid",
@@ -2517,21 +854,36 @@
           "size_width",
           "size_height"
         ],
-        "title": "AtlasTileGridSquarePositionResponse"
+        "title": "AtlasTileGridSquarePositionResponse",
+        "type": "object"
       },
       "AtlasTileResponse": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
           "atlas_uuid": {
-            "type": "string",
-            "title": "Atlas Uuid"
+            "title": "Atlas Uuid",
+            "type": "string"
           },
-          "tile_id": {
-            "type": "string",
-            "title": "Tile Id"
+          "base_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Filename"
+          },
+          "file_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Format"
           },
           "position_x": {
             "anyOf": [
@@ -2577,30 +929,15 @@
             ],
             "title": "Size Y"
           },
-          "file_format": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "File Format"
+          "tile_id": {
+            "title": "Tile Id",
+            "type": "string"
           },
-          "base_filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Base Filename"
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "atlas_uuid",
@@ -2612,11 +949,12 @@
           "file_format",
           "base_filename"
         ],
-        "title": "AtlasTileResponse"
+        "title": "AtlasTileResponse",
+        "type": "object"
       },
       "AtlasTileUpdateRequest": {
         "properties": {
-          "uuid": {
+          "atlas_uuid": {
             "anyOf": [
               {
                 "type": "string"
@@ -2625,9 +963,9 @@
                 "type": "null"
               }
             ],
-            "title": "Uuid"
+            "title": "Atlas Uuid"
           },
-          "tile_id": {
+          "base_filename": {
             "anyOf": [
               {
                 "type": "string"
@@ -2636,7 +974,18 @@
                 "type": "null"
               }
             ],
-            "title": "Tile Id"
+            "title": "Base Filename"
+          },
+          "file_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Format"
           },
           "position_x": {
             "anyOf": [
@@ -2682,7 +1031,7 @@
             ],
             "title": "Size Y"
           },
-          "file_format": {
+          "tile_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -2691,36 +1040,8 @@
                 "type": "null"
               }
             ],
-            "title": "File Format"
+            "title": "Tile Id"
           },
-          "base_filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Base Filename"
-          },
-          "atlas_uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atlas Uuid"
-          }
-        },
-        "type": "object",
-        "title": "AtlasTileUpdateRequest"
-      },
-      "AtlasUpdateRequest": {
-        "properties": {
           "uuid": {
             "anyOf": [
               {
@@ -2731,6 +1052,24 @@
               }
             ],
             "title": "Uuid"
+          }
+        },
+        "title": "AtlasTileUpdateRequest",
+        "type": "object"
+      },
+      "AtlasUpdateRequest": {
+        "properties": {
+          "acquisition_date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Date"
           },
           "atlas_id": {
             "anyOf": [
@@ -2743,6 +1082,17 @@
             ],
             "title": "Atlas Id"
           },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
           "grid_uuid": {
             "anyOf": [
               {
@@ -2754,17 +1104,16 @@
             ],
             "title": "Grid Uuid"
           },
-          "acquisition_date": {
+          "name": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Acquisition Date"
+            "title": "Name"
           },
           "storage_folder": {
             "anyOf": [
@@ -2777,7 +1126,7 @@
             ],
             "title": "Storage Folder"
           },
-          "description": {
+          "uuid": {
             "anyOf": [
               {
                 "type": "string"
@@ -2786,41 +1135,51 @@
                 "type": "null"
               }
             ],
-            "title": "Description"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
+            "title": "Uuid"
           }
         },
-        "type": "object",
-        "title": "AtlasUpdateRequest"
+        "title": "AtlasUpdateRequest",
+        "type": "object"
+      },
+      "CtfEstimationCompletedRequest": {
+        "properties": {
+          "ctf_max_res": {
+            "title": "Ctf Max Res",
+            "type": "number"
+          }
+        },
+        "required": [
+          "ctf_max_res"
+        ],
+        "title": "CtfEstimationCompletedRequest",
+        "type": "object"
+      },
+      "CtfEstimationRegisteredRequest": {
+        "properties": {
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "quality": {
+            "title": "Quality",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "quality"
+        ],
+        "title": "CtfEstimationRegisteredRequest",
+        "type": "object"
       },
       "FoilHoleCreateRequest": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "foilhole_id": {
-            "type": "string",
-            "title": "Foilhole Id"
-          },
-          "gridsquare_id": {
-            "type": "string",
-            "title": "Gridsquare Id"
-          },
-          "gridsquare_uuid": {
-            "type": "string",
-            "title": "Gridsquare Uuid"
-          },
           "center_x": {
             "anyOf": [
               {
@@ -2842,6 +1201,34 @@
               }
             ],
             "title": "Center Y"
+          },
+          "diameter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diameter"
+          },
+          "foilhole_id": {
+            "title": "Foilhole Id",
+            "type": "string"
+          },
+          "gridsquare_id": {
+            "title": "Gridsquare Id",
+            "type": "string"
+          },
+          "gridsquare_uuid": {
+            "title": "Gridsquare Uuid",
+            "type": "string"
+          },
+          "is_near_grid_bar": {
+            "default": false,
+            "title": "Is Near Grid Bar",
+            "type": "boolean"
           },
           "quality": {
             "anyOf": [
@@ -2865,17 +1252,6 @@
             ],
             "title": "Rotation"
           },
-          "size_width": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Width"
-          },
           "size_height": {
             "anyOf": [
               {
@@ -2887,29 +1263,7 @@
             ],
             "title": "Size Height"
           },
-          "x_location": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "X Location"
-          },
-          "y_location": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Y Location"
-          },
-          "x_stage_position": {
+          "size_width": {
             "anyOf": [
               {
                 "type": "number"
@@ -2918,34 +1272,7 @@
                 "type": "null"
               }
             ],
-            "title": "X Stage Position"
-          },
-          "y_stage_position": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Y Stage Position"
-          },
-          "diameter": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Diameter"
-          },
-          "is_near_grid_bar": {
-            "type": "boolean",
-            "title": "Is Near Grid Bar",
-            "default": false
+            "title": "Size Width"
           },
           "status": {
             "anyOf": [
@@ -2956,41 +1283,67 @@
                 "type": "null"
               }
             ]
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          },
+          "x_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Location"
+          },
+          "x_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Stage Position"
+          },
+          "y_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Location"
+          },
+          "y_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Stage Position"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "foilhole_id",
           "gridsquare_id",
           "gridsquare_uuid"
         ],
-        "title": "FoilHoleCreateRequest"
+        "title": "FoilHoleCreateRequest",
+        "type": "object"
       },
       "FoilHoleResponse": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "gridsquare_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gridsquare Id"
-          },
-          "foilhole_id": {
-            "type": "string",
-            "title": "Foilhole Id"
-          },
-          "status": {
-            "$ref": "#/components/schemas/FoilHoleStatus"
-          },
           "center_x": {
             "anyOf": [
               {
@@ -3012,6 +1365,36 @@
               }
             ],
             "title": "Center Y"
+          },
+          "diameter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diameter"
+          },
+          "foilhole_id": {
+            "title": "Foilhole Id",
+            "type": "string"
+          },
+          "gridsquare_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Id"
+          },
+          "is_near_grid_bar": {
+            "title": "Is Near Grid Bar",
+            "type": "boolean"
           },
           "quality": {
             "anyOf": [
@@ -3035,6 +1418,17 @@
             ],
             "title": "Rotation"
           },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
           "size_width": {
             "anyOf": [
               {
@@ -3046,16 +1440,19 @@
             ],
             "title": "Size Width"
           },
-          "size_height": {
+          "status": {
             "anyOf": [
               {
-                "type": "number"
+                "$ref": "#/components/schemas/FoilHoleStatus"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Size Height"
+            ]
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           },
           "x_location": {
             "anyOf": [
@@ -3068,17 +1465,6 @@
             ],
             "title": "X Location"
           },
-          "y_location": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Y Location"
-          },
           "x_stage_position": {
             "anyOf": [
               {
@@ -3090,6 +1476,17 @@
             ],
             "title": "X Stage Position"
           },
+          "y_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Location"
+          },
           "y_stage_position": {
             "anyOf": [
               {
@@ -3100,24 +1497,8 @@
               }
             ],
             "title": "Y Stage Position"
-          },
-          "diameter": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Diameter"
-          },
-          "is_near_grid_bar": {
-            "type": "boolean",
-            "title": "Is Near Grid Bar"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "gridsquare_id",
@@ -3136,28 +1517,51 @@
           "diameter",
           "is_near_grid_bar"
         ],
-        "title": "FoilHoleResponse"
+        "title": "FoilHoleResponse",
+        "type": "object"
       },
       "FoilHoleStatus": {
-        "type": "string",
         "enum": [
           "none",
           "micrographs detected"
         ],
-        "title": "FoilHoleStatus"
+        "title": "FoilHoleStatus",
+        "type": "string"
       },
       "FoilHoleUpdateRequest": {
         "properties": {
-          "uuid": {
+          "center_x": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "number"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Uuid"
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "diameter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diameter"
           },
           "foilhole_id": {
             "anyOf": [
@@ -3192,27 +1596,10 @@
             ],
             "title": "Gridsquare Uuid"
           },
-          "center_x": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center X"
-          },
-          "center_y": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Y"
+          "is_near_grid_bar": {
+            "default": false,
+            "title": "Is Near Grid Bar",
+            "type": "boolean"
           },
           "quality": {
             "anyOf": [
@@ -3236,6 +1623,17 @@
             ],
             "title": "Rotation"
           },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
           "size_width": {
             "anyOf": [
               {
@@ -3247,16 +1645,26 @@
             ],
             "title": "Size Width"
           },
-          "size_height": {
+          "status": {
             "anyOf": [
               {
-                "type": "number"
+                "$ref": "#/components/schemas/FoilHoleStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Size Height"
+            "title": "Uuid"
           },
           "x_location": {
             "anyOf": [
@@ -3269,17 +1677,6 @@
             ],
             "title": "X Location"
           },
-          "y_location": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Y Location"
-          },
           "x_stage_position": {
             "anyOf": [
               {
@@ -3291,6 +1688,17 @@
             ],
             "title": "X Stage Position"
           },
+          "y_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Location"
+          },
           "y_stage_position": {
             "anyOf": [
               {
@@ -3301,71 +1709,16 @@
               }
             ],
             "title": "Y Stage Position"
-          },
-          "diameter": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Diameter"
-          },
-          "is_near_grid_bar": {
-            "type": "boolean",
-            "title": "Is Near Grid Bar",
-            "default": false
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/FoilHoleStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
-        "type": "object",
-        "title": "FoilHoleUpdateRequest"
+        "title": "FoilHoleUpdateRequest",
+        "type": "object"
       },
       "GridCreateRequest": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
           "acquisition_uuid": {
-            "type": "string",
-            "title": "Acquisition Uuid"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GridStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Dir"
+            "title": "Acquisition Uuid",
+            "type": "string"
           },
           "atlas_dir": {
             "anyOf": [
@@ -3378,11 +1731,38 @@
             ],
             "title": "Atlas Dir"
           },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "scan_end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan End Time"
+          },
           "scan_start_time": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -3390,33 +1770,31 @@
             ],
             "title": "Scan Start Time"
           },
-          "scan_end_time": {
+          "status": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "$ref": "#/components/schemas/GridStatus"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Scan End Time"
+            ]
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "name",
           "acquisition_uuid"
         ],
-        "title": "GridCreateRequest"
+        "title": "GridCreateRequest",
+        "type": "object"
       },
       "GridResponse": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
           "acquisition_uuid": {
             "anyOf": [
               {
@@ -3427,31 +1805,6 @@
               }
             ],
             "title": "Acquisition Uuid"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GridStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Dir"
           },
           "atlas_dir": {
             "anyOf": [
@@ -3464,11 +1817,38 @@
             ],
             "title": "Atlas Dir"
           },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "scan_end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan End Time"
+          },
           "scan_start_time": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -3476,20 +1856,21 @@
             ],
             "title": "Scan Start Time"
           },
-          "scan_end_time": {
+          "status": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "$ref": "#/components/schemas/GridStatus"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Scan End Time"
+            ]
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "acquisition_uuid",
@@ -3500,32 +1881,33 @@
           "scan_start_time",
           "scan_end_time"
         ],
-        "title": "GridResponse"
+        "title": "GridResponse",
+        "type": "object"
       },
-      "GridSquareCreateRequest": {
+      "GridSquare": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "gridsquare_id": {
-            "type": "string",
-            "title": "Gridsquare Id"
-          },
-          "grid_uuid": {
-            "type": "string",
-            "title": "Grid Uuid"
-          },
-          "data_dir": {
+          "acquisition_datetime": {
             "anyOf": [
               {
+                "format": "date-time",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Data Dir"
+            "title": "Acquisition Datetime"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
           },
           "atlas_node_id": {
             "anyOf": [
@@ -3538,7 +1920,29 @@
             ],
             "title": "Atlas Node Id"
           },
-          "state": {
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "data_dir": {
             "anyOf": [
               {
                 "type": "string"
@@ -3547,9 +1951,9 @@
                 "type": "null"
               }
             ],
-            "title": "State"
+            "title": "Data Dir"
           },
-          "rotation": {
+          "defocus": {
             "anyOf": [
               {
                 "type": "number"
@@ -3558,7 +1962,34 @@
                 "type": "null"
               }
             ],
-            "title": "Rotation"
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "grid_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grid Uuid"
+          },
+          "gridsquare_id": {
+            "default": "",
+            "title": "Gridsquare Id",
+            "type": "string"
           },
           "image_path": {
             "anyOf": [
@@ -3571,6 +2002,61 @@
             ],
             "title": "Image Path"
           },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
           "selected": {
             "anyOf": [
               {
@@ -3582,16 +2068,27 @@
             ],
             "title": "Selected"
           },
-          "unusable": {
+          "size_height": {
             "anyOf": [
               {
-                "type": "boolean"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Unusable"
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
           },
           "stage_position_x": {
             "anyOf": [
@@ -3626,6 +2123,112 @@
             ],
             "title": "Stage Position Z"
           },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          },
+          "status": {
+            "$ref": "#/components/schemas/GridSquareStatus",
+            "default": "none"
+          },
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unusable"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid"
+        ],
+        "title": "GridSquare",
+        "type": "object"
+      },
+      "GridSquareBatchCreateRequest": {
+        "properties": {
+          "gridsquares": {
+            "items": {
+              "$ref": "#/components/schemas/GridSquareCreateRequest"
+            },
+            "title": "Gridsquares",
+            "type": "array"
+          }
+        },
+        "required": [
+          "gridsquares"
+        ],
+        "title": "GridSquareBatchCreateRequest",
+        "type": "object"
+      },
+      "GridSquareBatchCreateResponse": {
+        "description": "Response for bulk grid-square creation.",
+        "properties": {
+          "gridsquares": {
+            "items": {
+              "$ref": "#/components/schemas/GridSquareResponse"
+            },
+            "title": "Gridsquares",
+            "type": "array"
+          }
+        },
+        "required": [
+          "gridsquares"
+        ],
+        "title": "GridSquareBatchCreateResponse",
+        "type": "object"
+      },
+      "GridSquareCreateRequest": {
+        "properties": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
+          },
+          "atlas_node_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Node Id"
+          },
           "center_x": {
             "anyOf": [
               {
@@ -3647,6 +2250,74 @@
               }
             ],
             "title": "Center Y"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "gridsquare_id": {
+            "title": "Gridsquare Id",
+            "type": "string"
+          },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
+          "lowmag": {
+            "default": false,
+            "title": "Lowmag",
+            "type": "boolean"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
           },
           "physical_x": {
             "anyOf": [
@@ -3670,62 +2341,6 @@
             ],
             "title": "Physical Y"
           },
-          "size_width": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Width"
-          },
-          "size_height": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Height"
-          },
-          "acquisition_datetime": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Datetime"
-          },
-          "defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Defocus"
-          },
-          "magnification": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Magnification"
-          },
           "pixel_size": {
             "anyOf": [
               {
@@ -3737,18 +2352,7 @@
             ],
             "title": "Pixel Size"
           },
-          "detector_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detector Name"
-          },
-          "applied_defocus": {
+          "rotation": {
             "anyOf": [
               {
                 "type": "number"
@@ -3757,7 +2361,84 @@
                 "type": "null"
               }
             ],
-            "title": "Applied Defocus"
+            "title": "Rotation"
+          },
+          "selected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "stage_position_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position X"
+          },
+          "stage_position_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Y"
+          },
+          "stage_position_z": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Z"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
           },
           "status": {
             "anyOf": [
@@ -3769,89 +2450,93 @@
               }
             ]
           },
-          "lowmag": {
-            "type": "boolean",
-            "title": "Lowmag",
-            "default": false
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unusable"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "gridsquare_id",
           "grid_uuid"
         ],
-        "title": "GridSquareCreateRequest"
+        "title": "GridSquareCreateRequest",
+        "type": "object"
       },
       "GridSquarePositionRequest": {
         "properties": {
           "center_x": {
-            "type": "integer",
-            "title": "Center X"
+            "title": "Center X",
+            "type": "integer"
           },
           "center_y": {
-            "type": "integer",
-            "title": "Center Y"
+            "title": "Center Y",
+            "type": "integer"
           },
-          "size_width": {
-            "type": "integer",
-            "title": "Size Width"
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
           },
           "size_height": {
-            "type": "integer",
-            "title": "Size Height"
+            "title": "Size Height",
+            "type": "integer"
+          },
+          "size_width": {
+            "title": "Size Width",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
           "center_x",
           "center_y",
           "size_width",
           "size_height"
         ],
-        "title": "GridSquarePositionRequest"
+        "title": "GridSquarePositionRequest",
+        "type": "object"
       },
       "GridSquareResponse": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "gridsquare_id": {
-            "type": "string",
-            "title": "Gridsquare Id"
-          },
-          "grid_uuid": {
+          "acquisition_datetime": {
             "anyOf": [
               {
+                "format": "date-time",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Grid Uuid"
+            "title": "Acquisition Datetime"
           },
-          "status": {
+          "applied_defocus": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GridSquareStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
+                "type": "number"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Data Dir"
+            "title": "Applied Defocus"
           },
           "atlas_node_id": {
             "anyOf": [
@@ -3864,7 +2549,29 @@
             ],
             "title": "Atlas Node Id"
           },
-          "state": {
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "data_dir": {
             "anyOf": [
               {
                 "type": "string"
@@ -3873,9 +2580,9 @@
                 "type": "null"
               }
             ],
-            "title": "State"
+            "title": "Data Dir"
           },
-          "rotation": {
+          "defocus": {
             "anyOf": [
               {
                 "type": "number"
@@ -3884,7 +2591,33 @@
                 "type": "null"
               }
             ],
-            "title": "Rotation"
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "grid_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grid Uuid"
+          },
+          "gridsquare_id": {
+            "title": "Gridsquare Id",
+            "type": "string"
           },
           "image_path": {
             "anyOf": [
@@ -3897,6 +2630,61 @@
             ],
             "title": "Image Path"
           },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
           "selected": {
             "anyOf": [
               {
@@ -3908,16 +2696,27 @@
             ],
             "title": "Selected"
           },
-          "unusable": {
+          "size_height": {
             "anyOf": [
               {
-                "type": "boolean"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Unusable"
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
           },
           "stage_position_x": {
             "anyOf": [
@@ -3952,118 +2751,7 @@
             ],
             "title": "Stage Position Z"
           },
-          "center_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center X"
-          },
-          "center_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Y"
-          },
-          "physical_x": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Physical X"
-          },
-          "physical_y": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Physical Y"
-          },
-          "size_width": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Width"
-          },
-          "size_height": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Height"
-          },
-          "acquisition_datetime": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Datetime"
-          },
-          "defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Defocus"
-          },
-          "magnification": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Magnification"
-          },
-          "pixel_size": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pixel Size"
-          },
-          "detector_name": {
+          "state": {
             "anyOf": [
               {
                 "type": "string"
@@ -4072,21 +2760,34 @@
                 "type": "null"
               }
             ],
-            "title": "Detector Name"
+            "title": "State"
           },
-          "applied_defocus": {
+          "status": {
             "anyOf": [
               {
-                "type": "number"
+                "$ref": "#/components/schemas/GridSquareStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Applied Defocus"
+            "title": "Unusable"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "uuid",
           "gridsquare_id",
@@ -4115,62 +2816,43 @@
           "detector_name",
           "applied_defocus"
         ],
-        "title": "GridSquareResponse"
+        "title": "GridSquareResponse",
+        "type": "object"
       },
       "GridSquareStatus": {
-        "type": "string",
         "enum": [
           "none",
+          "all foil holes registered",
           "foil holes decision started",
           "foil holes decision completed"
         ],
-        "title": "GridSquareStatus"
+        "title": "GridSquareStatus",
+        "type": "string"
       },
       "GridSquareUpdateRequest": {
         "properties": {
-          "uuid": {
+          "acquisition_datetime": {
             "anyOf": [
               {
+                "format": "date-time",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Uuid"
+            "title": "Acquisition Datetime"
           },
-          "gridsquare_id": {
+          "applied_defocus": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "number"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Gridsquare Id"
-          },
-          "grid_uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grid Uuid"
-          },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Dir"
+            "title": "Applied Defocus"
           },
           "atlas_node_id": {
             "anyOf": [
@@ -4183,7 +2865,29 @@
             ],
             "title": "Atlas Node Id"
           },
-          "state": {
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "data_dir": {
             "anyOf": [
               {
                 "type": "string"
@@ -4192,9 +2896,9 @@
                 "type": "null"
               }
             ],
-            "title": "State"
+            "title": "Data Dir"
           },
-          "rotation": {
+          "defocus": {
             "anyOf": [
               {
                 "type": "number"
@@ -4203,7 +2907,40 @@
                 "type": "null"
               }
             ],
-            "title": "Rotation"
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "grid_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grid Uuid"
+          },
+          "gridsquare_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Id"
           },
           "image_path": {
             "anyOf": [
@@ -4216,6 +2953,66 @@
             ],
             "title": "Image Path"
           },
+          "lowmag": {
+            "default": false,
+            "title": "Lowmag",
+            "type": "boolean"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
           "selected": {
             "anyOf": [
               {
@@ -4227,16 +3024,27 @@
             ],
             "title": "Selected"
           },
-          "unusable": {
+          "size_height": {
             "anyOf": [
               {
-                "type": "boolean"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Unusable"
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
           },
           "stage_position_x": {
             "anyOf": [
@@ -4271,118 +3079,7 @@
             ],
             "title": "Stage Position Z"
           },
-          "center_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center X"
-          },
-          "center_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Y"
-          },
-          "physical_x": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Physical X"
-          },
-          "physical_y": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Physical Y"
-          },
-          "size_width": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Width"
-          },
-          "size_height": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Height"
-          },
-          "acquisition_datetime": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Datetime"
-          },
-          "defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Defocus"
-          },
-          "magnification": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Magnification"
-          },
-          "pixel_size": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pixel Size"
-          },
-          "detector_name": {
+          "state": {
             "anyOf": [
               {
                 "type": "string"
@@ -4391,18 +3088,7 @@
                 "type": "null"
               }
             ],
-            "title": "Detector Name"
-          },
-          "applied_defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Applied Defocus"
+            "title": "State"
           },
           "status": {
             "anyOf": [
@@ -4414,28 +3100,17 @@
               }
             ]
           },
-          "lowmag": {
-            "type": "boolean",
-            "title": "Lowmag",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "GridSquareUpdateRequest"
-      },
-      "GridStatus": {
-        "type": "string",
-        "enum": [
-          "none",
-          "scan started",
-          "scan completed",
-          "grid squares decision started",
-          "grid squares decision completed"
-        ],
-        "title": "GridStatus"
-      },
-      "GridUpdateRequest": {
-        "properties": {
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unusable"
+          },
           "uuid": {
             "anyOf": [
               {
@@ -4446,18 +3121,24 @@
               }
             ],
             "title": "Uuid"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
+          }
+        },
+        "title": "GridSquareUpdateRequest",
+        "type": "object"
+      },
+      "GridStatus": {
+        "enum": [
+          "none",
+          "scan started",
+          "scan completed",
+          "grid squares decision started",
+          "grid squares decision completed"
+        ],
+        "title": "GridStatus",
+        "type": "string"
+      },
+      "GridUpdateRequest": {
+        "properties": {
           "acquisition_uuid": {
             "anyOf": [
               {
@@ -4468,27 +3149,6 @@
               }
             ],
             "title": "Acquisition Uuid"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GridStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Dir"
           },
           "atlas_dir": {
             "anyOf": [
@@ -4501,11 +3161,45 @@
             ],
             "title": "Atlas Dir"
           },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "scan_end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan End Time"
+          },
           "scan_start_time": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -4513,21 +3207,30 @@
             ],
             "title": "Scan Start Time"
           },
-          "scan_end_time": {
+          "status": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "$ref": "#/components/schemas/GridStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Scan End Time"
+            "title": "Uuid"
           }
         },
-        "type": "object",
-        "title": "GridUpdateRequest"
+        "title": "GridUpdateRequest",
+        "type": "object"
       },
       "HTTPValidationError": {
         "properties": {
@@ -4535,78 +3238,124 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             },
-            "type": "array",
-            "title": "Detail"
+            "title": "Detail",
+            "type": "array"
           }
         },
-        "type": "object",
-        "title": "HTTPValidationError"
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "LatentRepresentationResponse": {
+        "properties": {
+          "foilhole_uuid": {
+            "default": "",
+            "title": "Foilhole Uuid",
+            "type": "string"
+          },
+          "gridsquare_uuid": {
+            "default": "",
+            "title": "Gridsquare Uuid",
+            "type": "string"
+          },
+          "index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index"
+          },
+          "x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X"
+          },
+          "y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y"
+          }
+        },
+        "required": [
+          "x",
+          "y",
+          "index"
+        ],
+        "title": "LatentRepresentationResponse",
+        "type": "object"
       },
       "MicrographCreateRequest": {
         "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "foilhole_uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Foilhole Uuid"
-          },
-          "foilhole_id": {
-            "type": "string",
-            "title": "Foilhole Id"
-          },
-          "location_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Location Id"
-          },
-          "high_res_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "High Res Path"
-          },
-          "manifest_file": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manifest File"
-          },
           "acquisition_datetime": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Acquisition Datetime"
+          },
+          "average_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Motion"
+          },
+          "binning_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning X"
+          },
+          "binning_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning Y"
+          },
+          "ctf_max_resolution_estimate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ctf Max Resolution Estimate"
           },
           "defocus": {
             "anyOf": [
@@ -4641,16 +3390,31 @@
             ],
             "title": "Energy Filter"
           },
-          "phase_plate": {
+          "foilhole_id": {
+            "title": "Foilhole Id",
+            "type": "string"
+          },
+          "foilhole_uuid": {
             "anyOf": [
               {
-                "type": "boolean"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Phase Plate"
+            "title": "Foilhole Uuid"
+          },
+          "high_res_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "High Res Path"
           },
           "image_size_x": {
             "anyOf": [
@@ -4674,6 +3438,146 @@
             ],
             "title": "Image Size Y"
           },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          },
+          "manifest_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manifest File"
+          },
+          "number_of_particles_picked": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Picked"
+          },
+          "number_of_particles_rejected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Rejected"
+          },
+          "number_of_particles_selected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Selected"
+          },
+          "phase_plate": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase Plate"
+          },
+          "pick_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pick Distribution"
+          },
+          "selection_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection Distribution"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MicrographStatus",
+            "default": "none"
+          },
+          "total_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Motion"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "foilhole_id"
+        ],
+        "title": "MicrographCreateRequest",
+        "type": "object"
+      },
+      "MicrographResponse": {
+        "properties": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "average_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Motion"
+          },
           "binning_x": {
             "anyOf": [
               {
@@ -4696,28 +3600,6 @@
             ],
             "title": "Binning Y"
           },
-          "total_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Motion"
-          },
-          "average_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Average Motion"
-          },
           "ctf_max_resolution_estimate": {
             "anyOf": [
               {
@@ -4729,29 +3611,18 @@
             ],
             "title": "Ctf Max Resolution Estimate"
           },
-          "number_of_particles_selected": {
+          "defocus": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "number"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Number Of Particles Selected"
+            "title": "Defocus"
           },
-          "number_of_particles_rejected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Rejected"
-          },
-          "selection_distribution": {
+          "detector_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -4760,51 +3631,18 @@
                 "type": "null"
               }
             ],
-            "title": "Selection Distribution"
+            "title": "Detector Name"
           },
-          "number_of_particles_picked": {
+          "energy_filter": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Number Of Particles Picked"
-          },
-          "pick_distribution": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pick Distribution"
-          },
-          "status": {
-            "$ref": "#/components/schemas/MicrographStatus",
-            "default": "none"
-          }
-        },
-        "type": "object",
-        "required": [
-          "uuid",
-          "foilhole_id"
-        ],
-        "title": "MicrographCreateRequest"
-      },
-      "MicrographResponse": {
-        "properties": {
-          "uuid": {
-            "type": "string",
-            "title": "Uuid"
-          },
-          "foilhole_uuid": {
-            "type": "string",
-            "title": "Foilhole Uuid"
+            "title": "Energy Filter"
           },
           "foilhole_id": {
             "anyOf": [
@@ -4816,6 +3654,65 @@
               }
             ],
             "title": "Foilhole Id"
+          },
+          "foilhole_uuid": {
+            "title": "Foilhole Uuid",
+            "type": "string"
+          },
+          "high_res_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "High Res Path"
+          },
+          "image_size_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size X"
+          },
+          "image_size_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size Y"
+          },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          },
+          "manifest_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manifest File"
           },
           "micrograph_id": {
             "anyOf": [
@@ -4828,7 +3725,51 @@
             ],
             "title": "Micrograph Id"
           },
-          "location_id": {
+          "number_of_particles_picked": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Picked"
+          },
+          "number_of_particles_rejected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Rejected"
+          },
+          "number_of_particles_selected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Selected"
+          },
+          "phase_plate": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase Plate"
+          },
+          "pick_distribution": {
             "anyOf": [
               {
                 "type": "string"
@@ -4837,44 +3778,118 @@
                 "type": "null"
               }
             ],
-            "title": "Location Id"
+            "title": "Pick Distribution"
+          },
+          "selection_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection Distribution"
           },
           "status": {
             "$ref": "#/components/schemas/MicrographStatus"
           },
-          "high_res_path": {
+          "total_motion": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "number"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "High Res Path"
+            "title": "Total Motion"
           },
-          "manifest_file": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manifest File"
-          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "foilhole_uuid",
+          "status"
+        ],
+        "title": "MicrographResponse",
+        "type": "object"
+      },
+      "MicrographStatus": {
+        "enum": [
+          "none",
+          "motion correction started",
+          "motion correction completed",
+          "ctf started",
+          "ctf completed",
+          "particle picking started",
+          "particle picking completed",
+          "particle selection started",
+          "particle selection completed"
+        ],
+        "title": "MicrographStatus",
+        "type": "string"
+      },
+      "MicrographUpdateRequest": {
+        "properties": {
           "acquisition_datetime": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Acquisition Datetime"
+          },
+          "average_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Motion"
+          },
+          "binning_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning X"
+          },
+          "binning_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning Y"
+          },
+          "ctf_max_resolution_estimate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ctf Max Resolution Estimate"
           },
           "defocus": {
             "anyOf": [
@@ -4908,197 +3923,6 @@
               }
             ],
             "title": "Energy Filter"
-          },
-          "phase_plate": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phase Plate"
-          },
-          "image_size_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Image Size X"
-          },
-          "image_size_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Image Size Y"
-          },
-          "binning_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning X"
-          },
-          "binning_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning Y"
-          },
-          "total_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Motion"
-          },
-          "average_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Average Motion"
-          },
-          "ctf_max_resolution_estimate": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ctf Max Resolution Estimate"
-          },
-          "number_of_particles_selected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Selected"
-          },
-          "number_of_particles_rejected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Rejected"
-          },
-          "selection_distribution": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Selection Distribution"
-          },
-          "number_of_particles_picked": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Picked"
-          },
-          "pick_distribution": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pick Distribution"
-          }
-        },
-        "type": "object",
-        "required": [
-          "uuid",
-          "foilhole_uuid",
-          "status"
-        ],
-        "title": "MicrographResponse"
-      },
-      "MicrographStatus": {
-        "type": "string",
-        "enum": [
-          "none",
-          "motion correction started",
-          "motion correction completed",
-          "ctf started",
-          "ctf completed",
-          "particle picking started",
-          "particle picking completed",
-          "particle selection started",
-          "particle selection completed"
-        ],
-        "title": "MicrographStatus"
-      },
-      "MicrographUpdateRequest": {
-        "properties": {
-          "uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uuid"
-          },
-          "foilhole_uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Foilhole Uuid"
           },
           "foilhole_id": {
             "anyOf": [
@@ -5111,7 +3935,7 @@
             ],
             "title": "Foilhole Id"
           },
-          "location_id": {
+          "foilhole_uuid": {
             "anyOf": [
               {
                 "type": "string"
@@ -5120,7 +3944,7 @@
                 "type": "null"
               }
             ],
-            "title": "Location Id"
+            "title": "Foilhole Uuid"
           },
           "high_res_path": {
             "anyOf": [
@@ -5132,73 +3956,6 @@
               }
             ],
             "title": "High Res Path"
-          },
-          "manifest_file": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manifest File"
-          },
-          "acquisition_datetime": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Datetime"
-          },
-          "defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Defocus"
-          },
-          "detector_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detector Name"
-          },
-          "energy_filter": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Energy Filter"
-          },
-          "phase_plate": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phase Plate"
           },
           "image_size_x": {
             "anyOf": [
@@ -5222,84 +3979,7 @@
             ],
             "title": "Image Size Y"
           },
-          "binning_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning X"
-          },
-          "binning_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning Y"
-          },
-          "total_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Motion"
-          },
-          "average_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Average Motion"
-          },
-          "ctf_max_resolution_estimate": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ctf Max Resolution Estimate"
-          },
-          "number_of_particles_selected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Selected"
-          },
-          "number_of_particles_rejected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Rejected"
-          },
-          "selection_distribution": {
+          "location_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -5308,7 +3988,18 @@
                 "type": "null"
               }
             ],
-            "title": "Selection Distribution"
+            "title": "Location Id"
+          },
+          "manifest_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manifest File"
           },
           "number_of_particles_picked": {
             "anyOf": [
@@ -5321,6 +4012,39 @@
             ],
             "title": "Number Of Particles Picked"
           },
+          "number_of_particles_rejected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Rejected"
+          },
+          "number_of_particles_selected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Selected"
+          },
+          "phase_plate": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase Plate"
+          },
           "pick_distribution": {
             "anyOf": [
               {
@@ -5332,13 +4056,527 @@
             ],
             "title": "Pick Distribution"
           },
+          "selection_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection Distribution"
+          },
           "status": {
             "$ref": "#/components/schemas/MicrographStatus",
             "default": "none"
+          },
+          "total_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Motion"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
           }
         },
-        "type": "object",
-        "title": "MicrographUpdateRequest"
+        "title": "MicrographUpdateRequest",
+        "type": "object"
+      },
+      "MotionCorrectionCompletedRequest": {
+        "properties": {
+          "average_motion": {
+            "title": "Average Motion",
+            "type": "number"
+          },
+          "total_motion": {
+            "title": "Total Motion",
+            "type": "number"
+          }
+        },
+        "required": [
+          "total_motion",
+          "average_motion"
+        ],
+        "title": "MotionCorrectionCompletedRequest",
+        "type": "object"
+      },
+      "MotionCorrectionRegisteredRequest": {
+        "properties": {
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "quality": {
+            "title": "Quality",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "quality"
+        ],
+        "title": "MotionCorrectionRegisteredRequest",
+        "type": "object"
+      },
+      "OverallQualityPrediction": {
+        "properties": {
+          "foilhole_uuid": {
+            "title": "Foilhole Uuid",
+            "type": "string"
+          },
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "gridsquare_uuid": {
+            "title": "Gridsquare Uuid",
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "suggested_acquisition_index": {
+            "title": "Suggested Acquisition Index",
+            "type": "integer"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "value",
+          "suggested_acquisition_index",
+          "foilhole_uuid",
+          "grid_uuid",
+          "gridsquare_uuid"
+        ],
+        "title": "OverallQualityPrediction",
+        "type": "object"
+      },
+      "ProcessingFeedbackPublishResponse": {
+        "description": "Confirmation that a processing-feedback event was published to RabbitMQ.",
+        "properties": {
+          "published": {
+            "title": "Published",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "published"
+        ],
+        "title": "ProcessingFeedbackPublishResponse",
+        "type": "object"
+      },
+      "QualityMetricsResponse": {
+        "properties": {
+          "average_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Quality"
+          },
+          "max_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Quality"
+          },
+          "min_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Quality"
+          },
+          "models_count": {
+            "title": "Models Count",
+            "type": "integer"
+          },
+          "total_predictions": {
+            "title": "Total Predictions",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_predictions",
+          "average_quality",
+          "min_quality",
+          "max_quality",
+          "models_count"
+        ],
+        "title": "QualityMetricsResponse",
+        "type": "object"
+      },
+      "QualityPrediction": {
+        "properties": {
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "value",
+          "prediction_model_name"
+        ],
+        "title": "QualityPrediction",
+        "type": "object"
+      },
+      "QualityPredictionCreateRequest": {
+        "properties": {
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "value",
+          "prediction_model_name"
+        ],
+        "title": "QualityPredictionCreateRequest",
+        "type": "object"
+      },
+      "QualityPredictionModelCreateRequest": {
+        "properties": {
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "QualityPredictionModelCreateRequest",
+        "type": "object"
+      },
+      "QualityPredictionModelParameterResponse": {
+        "properties": {
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "group": {
+            "title": "Group",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "grid_uuid",
+          "timestamp",
+          "prediction_model_name",
+          "key",
+          "value",
+          "group"
+        ],
+        "title": "QualityPredictionModelParameterResponse",
+        "type": "object"
+      },
+      "QualityPredictionModelResponse": {
+        "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "title": "QualityPredictionModelResponse",
+        "type": "object"
+      },
+      "QualityPredictionModelUpdateRequest": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "title": "QualityPredictionModelUpdateRequest",
+        "type": "object"
+      },
+      "QualityPredictionModelWeight": {
+        "properties": {
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "micrograph_quality": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Micrograph Quality"
+          },
+          "micrograph_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Micrograph Uuid"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "weight": {
+            "title": "Weight",
+            "type": "number"
+          }
+        },
+        "required": [
+          "grid_uuid",
+          "prediction_model_name",
+          "weight"
+        ],
+        "title": "QualityPredictionModelWeight",
+        "type": "object"
+      },
+      "QualityPredictionResponse": {
+        "properties": {
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "prediction_model_name",
+          "value",
+          "timestamp"
+        ],
+        "title": "QualityPredictionResponse",
+        "type": "object"
       },
       "ValidationError": {
         "properties": {
@@ -5353,32 +4591,3434 @@
                 }
               ]
             },
-            "type": "array",
-            "title": "Location"
+            "title": "Location",
+            "type": "array"
           },
           "msg": {
-            "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "type": "string"
           },
           "type": {
-            "type": "string",
-            "title": "Error Type"
+            "title": "Error Type",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "loc",
           "msg",
           "type"
         ],
-        "title": "ValidationError"
+        "title": "ValidationError",
+        "type": "object"
       }
     }
   },
-  "servers": [
-    {
-      "url": "http://localhost:8001",
-      "description": "Local development server"
+  "info": {
+    "description": "API for accessing and managing electron microscopy data",
+    "title": "SmartEM Decisions Backend API",
+    "version": "0.1.1rc27.dev13+g15895622a.d20260416"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/acquisitions": {
+      "get": {
+        "description": "Get all acquisitions",
+        "operationId": "get_acquisitions_acquisitions_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AcquisitionResponse"
+                  },
+                  "title": "Response Get Acquisitions Acquisitions Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Acquisitions"
+      },
+      "post": {
+        "description": "Create a new acquisition",
+        "operationId": "create_acquisition_acquisitions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcquisitionCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Acquisition"
+      }
+    },
+    "/acquisitions/{acquisition_uuid}": {
+      "delete": {
+        "description": "Delete an acquisition",
+        "operationId": "delete_acquisition_acquisitions__acquisition_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Acquisition"
+      },
+      "get": {
+        "description": "Get a single acquisition by ID",
+        "operationId": "get_acquisition_acquisitions__acquisition_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Acquisition"
+      },
+      "put": {
+        "description": "Update an acquisition",
+        "operationId": "update_acquisition_acquisitions__acquisition_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcquisitionUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Acquisition"
+      }
+    },
+    "/acquisitions/{acquisition_uuid}/grids": {
+      "get": {
+        "description": "Get all grids for a specific acquisition",
+        "operationId": "get_acquisition_grids_acquisitions__acquisition_uuid__grids_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridResponse"
+                  },
+                  "title": "Response Get Acquisition Grids Acquisitions  Acquisition Uuid  Grids Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Acquisition Grids"
+      },
+      "post": {
+        "description": "Create a new grid for a specific acquisition",
+        "operationId": "create_acquisition_grid_acquisitions__acquisition_uuid__grids_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Acquisition Grid"
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/heartbeat": {
+      "post": {
+        "description": "Agent heartbeat endpoint to update connection health status.\n\nArgs:\n    agent_id: The agent identifier\n    session_id: The session identifier\n    db: Database session\n\nReturns:\n    Heartbeat response with status and timestamp",
+        "operationId": "agent_heartbeat_agent__agent_id__session__session_id__heartbeat_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Agent Heartbeat"
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/instructions/stream": {
+      "get": {
+        "description": "SSE endpoint for streaming instructions to agents for a specific session",
+        "operationId": "stream_instructions_agent__agent_id__session__session_id__instructions_stream_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stream Instructions"
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/instructions/{instruction_id}/ack": {
+      "post": {
+        "description": "HTTP endpoint for instruction acknowledgements with database persistence",
+        "operationId": "acknowledge_instruction_agent__agent_id__session__session_id__instructions__instruction_id__ack_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "instruction_id",
+            "required": true,
+            "schema": {
+              "title": "Instruction Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstructionAcknowledgement"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstructionAcknowledgementResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Acknowledge Instruction"
+      }
+    },
+    "/atlas-tiles": {
+      "get": {
+        "description": "Get all atlas tiles",
+        "operationId": "get_atlas_tiles_atlas_tiles_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileResponse"
+                  },
+                  "title": "Response Get Atlas Tiles Atlas Tiles Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Atlas Tiles"
+      }
+    },
+    "/atlas-tiles/{tile_uuid}": {
+      "delete": {
+        "description": "Delete an atlas tile by publishing to RabbitMQ",
+        "operationId": "delete_atlas_tile_atlas_tiles__tile_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Atlas Tile"
+      },
+      "get": {
+        "description": "Get a single atlas tile by ID",
+        "operationId": "get_atlas_tile_atlas_tiles__tile_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Atlas Tile"
+      },
+      "put": {
+        "description": "Update an atlas tile",
+        "operationId": "update_atlas_tile_atlas_tiles__tile_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasTileUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Atlas Tile"
+      }
+    },
+    "/atlas-tiles/{tile_uuid}/gridsquares": {
+      "post": {
+        "description": "Connect mutliple grid squares to a tile with its position information",
+        "operationId": "link_atlas_tile_to_gridsquares_atlas_tiles__tile_uuid__gridsquares_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/GridSquarePositionRequest"
+                },
+                "title": "Gridsquare Positions",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
+                  },
+                  "title": "Response Link Atlas Tile To Gridsquares Atlas Tiles  Tile Uuid  Gridsquares Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Link Atlas Tile To Gridsquares"
+      }
+    },
+    "/atlas-tiles/{tile_uuid}/gridsquares/{gridsquare_uuid}": {
+      "post": {
+        "description": "Connect a grid square to a tile with its position information",
+        "operationId": "link_atlas_tile_to_gridsquare_atlas_tiles__tile_uuid__gridsquares__gridsquare_uuid__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquarePositionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Link Atlas Tile To Gridsquare"
+      }
+    },
+    "/atlases": {
+      "get": {
+        "description": "Get all atlases",
+        "operationId": "get_atlases_atlases_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasResponse"
+                  },
+                  "title": "Response Get Atlases Atlases Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Atlases"
+      }
+    },
+    "/atlases/{atlas_uuid}": {
+      "delete": {
+        "description": "Delete an atlas by publishing to RabbitMQ",
+        "operationId": "delete_atlas_atlases__atlas_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Atlas"
+      },
+      "get": {
+        "description": "Get a single atlas by ID",
+        "operationId": "get_atlas_atlases__atlas_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Atlas"
+      },
+      "put": {
+        "description": "Update an atlas",
+        "operationId": "update_atlas_atlases__atlas_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Atlas"
+      }
+    },
+    "/atlases/{atlas_uuid}/tiles": {
+      "get": {
+        "description": "Get all tiles for a specific atlas",
+        "operationId": "get_atlas_tiles_by_atlas_atlases__atlas_uuid__tiles_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileResponse"
+                  },
+                  "title": "Response Get Atlas Tiles By Atlas Atlases  Atlas Uuid  Tiles Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Atlas Tiles By Atlas"
+      },
+      "post": {
+        "description": "Create a new tile for a specific atlas",
+        "operationId": "create_atlas_tile_for_atlas_atlases__atlas_uuid__tiles_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasTileCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Atlas Tile For Atlas"
+      }
+    },
+    "/debug/agent-connections": {
+      "get": {
+        "description": "Debug endpoint to view active agent connections",
+        "operationId": "get_active_connections_debug_agent_connections_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Active Connections"
+      }
+    },
+    "/debug/connection-stats": {
+      "get": {
+        "description": "Get real-time connection and session statistics",
+        "operationId": "get_connection_stats_debug_connection_stats_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Connection Stats"
+      }
+    },
+    "/debug/session/{session_id}/create-instruction": {
+      "post": {
+        "description": "Debug endpoint to create test instructions",
+        "operationId": "create_test_instruction_debug_session__session_id__create_instruction_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Instruction Data",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Test Instruction"
+      }
+    },
+    "/debug/session/{session_id}/instructions": {
+      "get": {
+        "description": "Debug endpoint to view instructions for a session",
+        "operationId": "get_session_instructions_debug_session__session_id__instructions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Session Instructions"
+      }
+    },
+    "/debug/sessions": {
+      "get": {
+        "description": "Debug endpoint to view all active sessions",
+        "operationId": "get_active_sessions_debug_sessions_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Active Sessions"
+      }
+    },
+    "/debug/sessions/create": {
+      "post": {
+        "description": "Debug endpoint to create test sessions",
+        "operationId": "create_test_session_debug_sessions_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Session Data",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Test Session"
+      }
+    },
+    "/debug/sessions/create-managed": {
+      "post": {
+        "description": "Create a session using the connection manager",
+        "operationId": "create_managed_session_debug_sessions_create_managed_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Session Data",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Managed Session"
+      }
+    },
+    "/debug/sessions/{session_id}/close": {
+      "delete": {
+        "description": "Close a session using the connection manager",
+        "operationId": "close_managed_session_debug_sessions__session_id__close_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Close Managed Session"
+      }
+    },
+    "/foilholes": {
+      "get": {
+        "description": "Get all foil holes",
+        "operationId": "get_foilholes_foilholes_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "title": "Response Get Foilholes Foilholes Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Foilholes"
+      }
+    },
+    "/foilholes/{foilhole_uuid}": {
+      "delete": {
+        "description": "Delete a foil hole by publishing to RabbitMQ",
+        "operationId": "delete_foilhole_foilholes__foilhole_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Foilhole"
+      },
+      "get": {
+        "description": "Get a single foil hole by ID",
+        "operationId": "get_foilhole_foilholes__foilhole_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoilHoleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Foilhole"
+      },
+      "put": {
+        "description": "Update a foil hole",
+        "operationId": "update_foilhole_foilholes__foilhole_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoilHoleUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoilHoleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Foilhole"
+      }
+    },
+    "/foilholes/{foilhole_uuid}/micrographs": {
+      "get": {
+        "description": "Get all micrographs for a specific foil hole",
+        "operationId": "get_foilhole_micrographs_foilholes__foilhole_uuid__micrographs_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MicrographResponse"
+                  },
+                  "title": "Response Get Foilhole Micrographs Foilholes  Foilhole Uuid  Micrographs Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Foilhole Micrographs"
+      },
+      "post": {
+        "description": "Create a new micrograph for a specific foil hole",
+        "operationId": "create_foilhole_micrograph_foilholes__foilhole_uuid__micrographs_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MicrographCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MicrographResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Foilhole Micrograph"
+      }
+    },
+    "/grid/{grid_uuid}/model_weights": {
+      "get": {
+        "description": "Get time series of model weights for grid",
+        "operationId": "get_model_weights_for_grid_grid__grid_uuid__model_weights_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/QualityPredictionModelWeight"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Get Model Weights For Grid Grid  Grid Uuid  Model Weights Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Model Weights For Grid"
+      }
+    },
+    "/grid/{grid_uuid}/prediction_model/{prediction_model_name}/latent_rep/{latent_rep_model_name}/suggested_squares": {
+      "get": {
+        "operationId": "get_suggested_square_collections_grid__grid_uuid__prediction_model__prediction_model_name__latent_rep__latent_rep_model_name__suggested_squares_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "latent_rep_model_name",
+            "required": true,
+            "schema": {
+              "title": "Latent Rep Model Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquare"
+                  },
+                  "title": "Response Get Suggested Square Collections Grid  Grid Uuid  Prediction Model  Prediction Model Name  Latent Rep  Latent Rep Model Name  Suggested Squares Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Suggested Square Collections"
+      }
+    },
+    "/grids": {
+      "get": {
+        "description": "Get all grids",
+        "operationId": "get_grids_grids_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridResponse"
+                  },
+                  "title": "Response Get Grids Grids Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Grids"
+      }
+    },
+    "/grids/{grid_uuid}": {
+      "delete": {
+        "description": "Delete a grid by publishing to RabbitMQ",
+        "operationId": "delete_grid_grids__grid_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Grid"
+      },
+      "get": {
+        "description": "Get a single grid by ID",
+        "operationId": "get_grid_grids__grid_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Grid"
+      },
+      "put": {
+        "description": "Update a grid",
+        "operationId": "update_grid_grids__grid_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Grid"
+      }
+    },
+    "/grids/{grid_uuid}/atlas": {
+      "get": {
+        "description": "Get the atlas for a specific grid",
+        "operationId": "get_grid_atlas_grids__grid_uuid__atlas_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Grid Atlas"
+      },
+      "post": {
+        "description": "Create a new atlas for a grid",
+        "operationId": "create_grid_atlas_grids__grid_uuid__atlas_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Grid Atlas"
+      }
+    },
+    "/grids/{grid_uuid}/atlas_image": {
+      "get": {
+        "description": "Get a single grid by ID",
+        "operationId": "get_grid_atlas_image_grids__grid_uuid__atlas_image_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "x",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X"
+            }
+          },
+          {
+            "in": "query",
+            "name": "y",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Y"
+            }
+          },
+          {
+            "in": "query",
+            "name": "w",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "W"
+            }
+          },
+          {
+            "in": "query",
+            "name": "h",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "H"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "image/png": {}
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Grid Atlas Image"
+      }
+    },
+    "/grids/{grid_uuid}/gridsquares": {
+      "get": {
+        "description": "Get all grid squares for a specific grid",
+        "operationId": "get_grid_gridsquares_grids__grid_uuid__gridsquares_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquareResponse"
+                  },
+                  "title": "Response Get Grid Gridsquares Grids  Grid Uuid  Gridsquares Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Grid Gridsquares"
+      },
+      "post": {
+        "description": "Create a new grid square for a specific grid",
+        "operationId": "create_grid_gridsquare_grids__grid_uuid__gridsquares_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Grid Gridsquare"
+      }
+    },
+    "/grids/{grid_uuid}/gridsquares/batch": {
+      "post": {
+        "description": "Create many grid squares for a grid in a single transaction and a single\nbatched RabbitMQ publish. Solves the overload scenario from issue #249.",
+        "operationId": "create_grid_gridsquares_batch_grids__grid_uuid__gridsquares_batch_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareBatchCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareBatchCreateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Grid Gridsquares Batch"
+      }
+    },
+    "/grids/{grid_uuid}/registered": {
+      "post": {
+        "description": "All squares on a grid have been registered at low mag",
+        "operationId": "grid_registered_grids__grid_uuid__registered_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Grid Registered Grids  Grid Uuid  Registered Post",
+                  "type": "boolean"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Grid Registered"
+      }
+    },
+    "/gridsquare/{gridsquare_uuid}/overall_prediction": {
+      "get": {
+        "operationId": "get_overall_prediction_for_gridsquare_gridsquare__gridsquare_uuid__overall_prediction_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OverallQualityPrediction"
+                  },
+                  "title": "Response Get Overall Prediction For Gridsquare Gridsquare  Gridsquare Uuid  Overall Prediction Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Overall Prediction For Gridsquare"
+      }
+    },
+    "/gridsquares": {
+      "get": {
+        "description": "Get all grid squares",
+        "operationId": "get_gridsquares_gridsquares_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquareResponse"
+                  },
+                  "title": "Response Get Gridsquares Gridsquares Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Gridsquares"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}": {
+      "delete": {
+        "description": "Delete a grid square by publishing to RabbitMQ",
+        "operationId": "delete_gridsquare_gridsquares__gridsquare_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Gridsquare"
+      },
+      "get": {
+        "description": "Get a single grid square by ID",
+        "operationId": "get_gridsquare_gridsquares__gridsquare_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gridsquare"
+      },
+      "put": {
+        "description": "Update a grid square",
+        "operationId": "update_gridsquare_gridsquares__gridsquare_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Gridsquare"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
+      "get": {
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "items": {
+                        "$ref": "#/components/schemas/QualityPrediction"
+                      },
+                      "type": "array"
+                    },
+                    "type": "object"
+                  },
+                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/foilholes": {
+      "get": {
+        "description": "Get all foil holes for a specific grid square",
+        "operationId": "get_gridsquare_foilholes_gridsquares__gridsquare_uuid__foilholes_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "on_square_only",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "On Square Only",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "title": "Response Get Gridsquare Foilholes Gridsquares  Gridsquare Uuid  Foilholes Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gridsquare Foilholes"
+      },
+      "post": {
+        "description": "Create a new foil hole for a specific grid square",
+        "operationId": "create_gridsquare_foilhole_gridsquares__gridsquare_uuid__foilholes_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/FoilHoleCreateRequest"
+                },
+                "title": "Foilholes",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "title": "Response Create Gridsquare Foilhole Gridsquares  Gridsquare Uuid  Foilholes Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Gridsquare Foilhole"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/gridsquare_image": {
+      "get": {
+        "description": "Get a single grid square by ID",
+        "operationId": "get_gridsquare_image_gridsquares__gridsquare_uuid__gridsquare_image_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "image/png": {}
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gridsquare Image"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/quality_predictions": {
+      "get": {
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_gridsquare_quality_prediction_time_series_gridsquares__gridsquare_uuid__quality_predictions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/QualityPrediction"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Get Gridsquare Quality Prediction Time Series Gridsquares  Gridsquare Uuid  Quality Predictions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gridsquare Quality Prediction Time Series"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/registered": {
+      "post": {
+        "description": "All holes on a grid square have been registered at square mag",
+        "operationId": "gridsquare_registered_gridsquares__gridsquare_uuid__registered_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "count",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Count"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Gridsquare Registered Gridsquares  Gridsquare Uuid  Registered Post",
+                  "type": "boolean"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Gridsquare Registered"
+      }
+    },
+    "/health": {
+      "get": {
+        "description": "Health check endpoint with actual connectivity checks",
+        "operationId": "get_health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Health"
+      }
+    },
+    "/micrographs": {
+      "get": {
+        "description": "Get all micrographs",
+        "operationId": "get_micrographs_micrographs_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MicrographResponse"
+                  },
+                  "title": "Response Get Micrographs Micrographs Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Micrographs"
+      }
+    },
+    "/micrographs/{micrograph_uuid}": {
+      "delete": {
+        "description": "Delete a micrograph by publishing to RabbitMQ",
+        "operationId": "delete_micrograph_micrographs__micrograph_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Micrograph"
+      },
+      "get": {
+        "description": "Get a single micrograph by ID",
+        "operationId": "get_micrograph_micrographs__micrograph_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MicrographResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Micrograph"
+      },
+      "put": {
+        "description": "Update a micrograph",
+        "operationId": "update_micrograph_micrographs__micrograph_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MicrographUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MicrographResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Micrograph"
+      }
+    },
+    "/micrographs/{micrograph_uuid}/ctf_estimation/completed": {
+      "post": {
+        "description": "Publish a CTF-estimation-completed event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_ctf_estimation_completed_micrographs__micrograph_uuid__ctf_estimation_completed_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CtfEstimationCompletedRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Publish Micrograph Ctf Estimation Completed"
+      }
+    },
+    "/micrographs/{micrograph_uuid}/ctf_estimation/registered": {
+      "post": {
+        "description": "Publish a CTF-estimation-registered event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_ctf_estimation_registered_micrographs__micrograph_uuid__ctf_estimation_registered_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CtfEstimationRegisteredRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Publish Micrograph Ctf Estimation Registered"
+      }
+    },
+    "/micrographs/{micrograph_uuid}/motion_correction/completed": {
+      "post": {
+        "description": "Publish a motion-correction-completed event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_motion_correction_completed_micrographs__micrograph_uuid__motion_correction_completed_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MotionCorrectionCompletedRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Publish Micrograph Motion Correction Completed"
+      }
+    },
+    "/micrographs/{micrograph_uuid}/motion_correction/registered": {
+      "post": {
+        "description": "Publish a motion-correction-registered event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_motion_correction_registered_micrographs__micrograph_uuid__motion_correction_registered_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MotionCorrectionRegisteredRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Publish Micrograph Motion Correction Registered"
+      }
+    },
+    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/latent_representation": {
+      "get": {
+        "operationId": "get_latent_rep_prediction_model__prediction_model_name__grid__grid_uuid__latent_representation_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/LatentRepresentationResponse"
+                  },
+                  "title": "Response Get Latent Rep Prediction Model  Prediction Model Name  Grid  Grid Uuid  Latent Representation Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Latent Rep"
+      }
+    },
+    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/prediction": {
+      "get": {
+        "operationId": "get_prediction_for_grid_prediction_model__prediction_model_name__grid__grid_uuid__prediction_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionResponse"
+                  },
+                  "title": "Response Get Prediction For Grid Prediction Model  Prediction Model Name  Grid  Grid Uuid  Prediction Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Prediction For Grid"
+      }
+    },
+    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/latent_representation": {
+      "get": {
+        "operationId": "get_square_latent_rep_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__latent_representation_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/LatentRepresentationResponse"
+                  },
+                  "title": "Response Get Square Latent Rep Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Latent Representation Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Square Latent Rep"
+      }
+    },
+    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/prediction": {
+      "get": {
+        "operationId": "get_prediction_for_gridsquare_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__prediction_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionResponse"
+                  },
+                  "title": "Response Get Prediction For Gridsquare Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Prediction Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Prediction For Gridsquare"
+      }
+    },
+    "/prediction_models": {
+      "get": {
+        "operationId": "get_prediction_models_prediction_models_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                  },
+                  "title": "Response Get Prediction Models Prediction Models Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Prediction Models"
+      },
+      "post": {
+        "operationId": "create_prediction_model_prediction_models_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionModelCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Prediction Model"
+      }
+    },
+    "/prediction_models/{name}": {
+      "delete": {
+        "operationId": "delete_prediction_model_prediction_models__name__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Prediction Model"
+      },
+      "get": {
+        "operationId": "get_prediction_model_prediction_models__name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Prediction Model"
+      },
+      "put": {
+        "operationId": "update_prediction_model_prediction_models__name__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionModelUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Prediction Model"
+      }
+    },
+    "/quality_metric/{metric_name}/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
+      "get": {
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_for_metric_quality_metric__metric_name__gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "metric_name",
+            "required": true,
+            "schema": {
+              "title": "Metric Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "items": {
+                        "$ref": "#/components/schemas/QualityPrediction"
+                      },
+                      "type": "array"
+                    },
+                    "type": "object"
+                  },
+                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare For Metric Quality Metric  Metric Name  Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare For Metric"
+      }
+    },
+    "/quality_metrics": {
+      "get": {
+        "operationId": "get_quality_metrics_quality_metrics_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityMetricsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Quality Metrics"
+      }
+    },
+    "/quality_predictions": {
+      "post": {
+        "operationId": "create_quality_prediction_quality_predictions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Quality Prediction"
+      }
+    },
+    "/status": {
+      "get": {
+        "description": "Get API status and configuration information",
+        "operationId": "get_status_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Status"
+      }
     }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary

One-shot regeneration of \`docs/api/smartem/swagger.json\` from smartem-decisions main. Relates to smartem-decisions#253.

The checked-in spec had been frozen at \`0.1.dev276+g1b7ed28d6.d20250818\` (August 2025) because there is no automation wired up between backend releases and this copy. Eight months of endpoint and schema additions have been invisible to every consumer that pulls this file — the frontend's Orval client regen (\`npm run api:update\` in \`packages/api\`) among them.

Regenerated from smartem-decisions@\`2c75a79\` (fix: populate ATLAS_CREATED event id from atlas_id, not name), which includes all of the recent work:

- #248 — post-commit SELECT storm fix
- #250 — processing-feedback publish endpoints
- #249 — bulk gridsquare creation endpoint
- #254 — ATLAS_CREATED event id field fix
- Plus ~8 months of prior work not tracked in the above issues.

## Delta

| | Old | New | Change |
|---|---:|---:|---|
| Paths | 25 | 58 | +33 added, 0 removed |
| Schemas | 30 | 51 | +21 added, 0 removed |

**Zero removals** — this is an additive-only sync, so existing generated clients will not break on regeneration.

### New path families

- Agent streaming + instruction lifecycle: \`/agent/{agent_id}/session/{session_id}/heartbeat\`, \`.../instructions/stream\`, \`.../instructions/{instruction_id}/ack\`
- Debug surface for session/instruction management: \`/debug/agent-connections\`, \`/debug/session/{session_id}/*\`, \`/debug/sessions/*\`
- Quality-prediction model surface: \`/prediction_models\`, \`/quality_predictions\`, \`/quality_metrics\`, \`/prediction_model/{name}/...\`
- Image endpoints: \`/grids/{grid_uuid}/atlas_image\`, \`/gridsquares/{gridsquare_uuid}/gridsquare_image\`
- Atlas tile gridsquare positions: \`/atlas-tiles/{tile_uuid}/gridsquares\`
- Bulk gridsquare creation: \`/grids/{grid_uuid}/gridsquares/batch\` (#249)
- Processing feedback: \`/micrographs/{uuid}/{motion_correction|ctf_estimation}/{completed|registered}\` (#250)

### New schema highlights

\`GridSquareBatchCreateRequest\`, \`GridSquareBatchCreateResponse\`, \`MotionCorrection*Request\`, \`CtfEstimation*Request\`, \`ProcessingFeedbackPublishResponse\`, \`AgentInstructionAcknowledgement\`, \`AgentInstructionAcknowledgementResponse\`, various quality/prediction models and responses.

## Generation command

\`\`\`
SKIP_DB_INIT=true uv run python -c \"
import logging, json, pathlib
logging.disable(logging.CRITICAL)
import smartem_backend.api_server as s
pathlib.Path('docs/api/smartem/swagger.json').write_text(
    json.dumps(s.app.openapi(), indent=2, sort_keys=True) + '\n'
)
\"
\`\`\`

(Run from a smartem-decisions checkout at the desired commit. Uses \`sort_keys=True\` to match the existing file's sorted-key convention, so future diffs stay readable.)

## Test plan

- [x] \`python -m json.tool docs/api/smartem/swagger.json\` — valid JSON.
- [x] Delta check: 0 removals (additive-only).
- [ ] **Consumer smoke** (to do manually after merge): in smartem-frontend, \`cd packages/api && npm run api:update\` — expect a clean regen with many new endpoints and types added, no breakage.

## Next step

Automating this sync via a GitHub Actions workflow (part of smartem-decisions#253) will be a follow-up PR. Intent to open it for discussion before implementation.