### PR TITLE
Drop trufflehog and detect-secrets in favour of gitleaks

### DIFF
--- a/core/dev-requirements.json
+++ b/core/dev-requirements.json
@@ -77,13 +77,6 @@
       "description": "Git hooks framework for code quality checks"
     },
     {
-      "name": "detect-secrets",
-      "command": "detect-secrets",
-      "versionArgs": ["--version"],
-      "required": false,
-      "description": "Secrets detection tool for baseline management"
-    },
-    {
       "name": "osv-scanner",
       "command": "osv-scanner",
       "versionArgs": ["--version"],

--- a/packages/smartem-workspace/smartem_workspace/config/dev-requirements.json
+++ b/packages/smartem-workspace/smartem_workspace/config/dev-requirements.json
@@ -77,13 +77,6 @@
       "description": "Git hooks framework for code quality checks"
     },
     {
-      "name": "detect-secrets",
-      "command": "detect-secrets",
-      "versionArgs": ["--version"],
-      "required": false,
-      "description": "Secrets detection tool for baseline management"
-    },
-    {
       "name": "osv-scanner",
       "command": "osv-scanner",
       "versionArgs": ["--version"],


### PR DESCRIPTION
## Summary

- Removed detect-secrets from dev-requirements.json (both core and smartem-workspace package copies)

Consolidating on gitleaks as the single secret scanning tool across the project. ADR 0005 was already marked as superseded.