### PR TITLE
fix: correct Renovate preset path and migrate matchPackagePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>DiamondLightSource/smartem-devtools:renovate/default"],
+  "extends": ["github>DiamondLightSource/smartem-devtools//renovate/default"],
   "packageRules": [
     {
       "description": "Group webui npm minor/patch",
@@ -14,7 +14,7 @@
       "matchManagers": ["npm"],
       "matchFileNames": ["webui/**"],
       "matchUpdateTypes": ["major"],
-      "matchPackagePatterns": ["^vite$", "^@vitejs/", "^@tailwindcss/vite$"],
+      "matchPackageNames": ["vite", "@tailwindcss/vite", "/^@vitejs//"],
       "groupName": "webui vite ecosystem major"
     },
     {


### PR DESCRIPTION
## Summary

Two related Renovate config cleanups.

### 1. Self-extending preset uses wrong separator (blocking)

This repo hosts the shared \`renovate/default.json\` preset, and its own \`renovate.json\` self-extends that preset. Renovate's reference syntax uses \`:\` for **sub-preset names** within a single file and \`//\` for **nested file paths**, so the correct reference is:

\`\`\`
github>DiamondLightSource/smartem-devtools//renovate/default
\`\`\`

The previous \`:\` form fails preset resolution (\"Preset name not found within published preset config\"), so Renovate cannot process this repo at all.

This is worth fixing here especially because this is the canonical example other DLS repos copy from. The same broken syntax was picked up in:

- DiamondLightSource/smartem-decisions#281
- DiamondLightSource/smartem-frontend#81
- DiamondLightSource/fandanGO-cryoem-dls#17

### 2. matchPackagePatterns -> matchPackageNames (cosmetic)

\`matchPackagePatterns\` was deprecated and Renovate auto-migrates it to \`matchPackageNames\` with the embedded \`/regex/\` syntax on every run. Auto-migration is silent and harmless, but pinning the replacement in source removes the migration step. Exact-name matches now use plain strings, prefix patterns keep regex form.

The \`playwright-skill\` and \`Python deps\` rules already used the modern form and are unchanged.

## Test plan

- [x] \`renovate-config-validator --strict\` passes
- [ ] After merge, confirm Renovate runs cleanly on this repo and the cascading fixes in dependent repos resolve cleanly