### PR TITLE
fix(deps): bump postcss 8.5.8 -> 8.5.14 (CVE-2026-41305)

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -6012,9 +6012,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary
- Bumps `postcss` 8.5.8 → 8.5.14 in `webui/package-lock.json` to clear [code scanning alert #18](https://github.com/DiamondLightSource/smartem-devtools/security/code-scanning/18) (CVE-2026-41305, GHSA-qx2v-qp2m-jg93).
- postcss is a transitive dependency via `vite`. The vulnerability is XSS via unescaped `</style>` when re-stringifying user-submitted CSS — not exploitable here (webui does not accept user CSS, postcss runs build-time only). Bump is purely to silence the scanner.
- Lockfile-only change (3 lines).

## Test plan
- [x] `npm install --package-lock-only postcss@8.5.14` resolves cleanly with no `package.json` change
- [x] Diff confirmed: only `webui/package-lock.json` touched
- [x] CI passes