### PR TITLE
feat: local Keycloak mock + backend auth env wiring

### DIFF
--- a/docs/agent/authentication.md
+++ b/docs/agent/authentication.md
@@ -1,0 +1,158 @@
+# SmartEM Agent Authentication
+
+The SmartEM Agent authenticates against the SmartEM Decisions backend using OAuth 2.0 Bearer tokens issued by Keycloak. This document describes how authentication works, how to configure it, how to operate it, and how to troubleshoot it.
+
+The architectural decision is recorded in [ADR 0018](../decision-records/decisions/0018-smartem-agent-keycloak-auth.md).
+
+## Overview
+
+The agent runs unattended on EPU workstations near the microscope. There is no browser and no human at startup, so the OIDC authorisation-code flow used by the SmartEM frontend does not apply. Instead the agent uses the OAuth 2.0 client_credentials grant: it presents a confidential client ID and secret to Keycloak, receives an access token, and attaches that token to every request it makes to the backend.
+
+```
++------------+  1. client_credentials grant    +------------+
+|            | ------------------------------> |            |
+|   Agent    |                                 |  Keycloak  |
+|            | <------------------------------ |            |
++------------+  2. Access token (RS256 JWT)    +------------+
+       |
+       | 3. HTTP request + Bearer token
+       v
++------------+
+|  Backend   |  Validates the token against the Keycloak JWKS
++------------+
+```
+
+The token is cached in memory and refreshed shortly before its expiry. If the backend rejects a request with HTTP 401, the agent invalidates its cache, fetches a fresh token, and retries the request once before surfacing the error. Long-running SSE connections that span a token's expiry briefly disconnect and reconnect with a fresh token; this is expected and is handled by the agent transparently.
+
+The Keycloak client used by the agent is `SmartEM_Agent`. This is distinct from the browser-facing `SmartEM_User` client used by the frontend; the backend distinguishes the two via the `azp` (authorised party) claim on the token.
+
+## Configuration
+
+The agent requires four values to authenticate.
+
+| Name | Purpose |
+|------|---------|
+| `KEYCLOAK_URL` | Base URL of the Keycloak server (e.g. `https://auth.diamond.ac.uk`). |
+| `KEYCLOAK_REALM` | Realm name (e.g. `dls`). |
+| `KEYCLOAK_CLIENT_ID` | Client identifier - `SmartEM_Agent` in normal operation. |
+| `KEYCLOAK_CLIENT_SECRET` | Confidential client secret, provided by the Keycloak administrator. |
+
+### Configuration file
+
+The agent reads these values from a dotenv-style configuration file. By default the file is located alongside the agent executable. To use a different location, pass `--config`:
+
+```bash
+python -m smartem_agent watch /path/to/data --config /opt/smartem/agent.env
+```
+
+The file format is one variable per line in `KEY=VALUE` form, with no quoting:
+
+```
+KEYCLOAK_URL=https://auth.diamond.ac.uk
+KEYCLOAK_REALM=dls
+KEYCLOAK_CLIENT_ID=SmartEM_Agent
+KEYCLOAK_CLIENT_SECRET=<secret here>
+```
+
+The four values are mandatory; if any are missing or empty, the agent exits with a non-zero status at startup and a clear error message. There is no fallback to unauthenticated operation.
+
+### File permissions
+
+**For operators.** The configuration file contains a credential. Restrict read access to the operating-system account that runs the agent. On POSIX-like systems (including Cygwin) `chmod 600` is sufficient. On Windows, restrict NTFS ACLs to the launching user.
+
+Storage hardening via OS-native secret stores (Windows DPAPI, Credential Manager, Linux keyring) is a possible future iteration but is intentionally out of scope for v1. The file-based approach keeps the agent OS-agnostic.
+
+## Operations
+
+### Token lifecycle
+
+Access tokens issued by Keycloak default to a 5-minute lifespan. The agent fetches tokens lazily on first use, caches them in memory, and refreshes them when within approximately 30 seconds of expiry. If a backend request returns HTTP 401, the agent invalidates the cache, fetches a fresh token, and retries the request once. A second 401 after refresh is surfaced as an error.
+
+The client_credentials grant does not issue refresh tokens. Each refresh is a full re-request against the Keycloak token endpoint.
+
+### Secret rotation
+
+Routine rotation:
+
+1. Generate a new secret for the `SmartEM_Agent` client in the Keycloak admin console.
+2. Update the configuration file on every agent workstation with the new secret.
+3. Restart each agent.
+
+The agent does not currently re-read its configuration file on signal; a restart is required to pick up a new secret. Until step 3 has completed on a given workstation, the agent on that workstation continues to use the old secret. If the old secret is still valid in Keycloak (no concurrent revocation), the agent continues to operate. If the old secret has been revoked, the agent sees 401s until restarted.
+
+Emergency rotation (suspected leak):
+
+1. Revoke the old secret in Keycloak.
+2. Distribute the new secret to all workstations.
+3. Restart each agent.
+
+All agents will see 401s between steps 1 and 3.
+
+### Logging
+
+The agent emits structured log entries at the following points:
+
+- **Token fetched.** Records the absolute expiry time (ISO 8601) and the local system time at the moment of fetch. Useful for diagnosing clock skew.
+- **Token refreshed.** Logged when proactive refresh occurs near expiry, or when a 401 forces an early refresh.
+- **Authentication failure.** Logged when token fetch fails (Keycloak unreachable, wrong secret, client disabled) or when a request continues to receive 401 after a refresh.
+
+Tokens themselves are never written to logs.
+
+## Development
+
+The local Keycloak mock at `smartem-devtools/keycloak-mock/` ships with a `SmartEM_Agent` client whose secret is hard-coded as `dev-agent-secret`. This value has no security significance and is used only for local development against the mock realm.
+
+To run the agent against the mock:
+
+1. Bring up the local k3s cluster including the Keycloak mock: `./scripts/k8s/dev-k8s.sh up`.
+2. Create an agent configuration file pointing at the mock:
+
+   ```
+   KEYCLOAK_URL=http://localhost:30090
+   KEYCLOAK_REALM=dls
+   KEYCLOAK_CLIENT_ID=SmartEM_Agent
+   KEYCLOAK_CLIENT_SECRET=dev-agent-secret
+   ```
+
+3. Run the agent with `--config` pointing at this file.
+
+Agent-side tests exercise: successful token fetch, proactive refresh near expiry, 401-triggered refresh and retry, network failure to Keycloak, and repeated 401 after refresh.
+
+## Troubleshooting
+
+### Agent exits at startup with a Keycloak configuration error
+
+The agent could not read one or more of the four required values. Verify the configuration file exists, is readable by the agent user, and contains all four variables with non-empty values.
+
+### Agent receives 401 on every request
+
+Possible causes, in roughly decreasing likelihood:
+
+1. **Wrong client secret.** Verify the secret in the configuration file matches the secret in the Keycloak admin console for the `SmartEM_Agent` client.
+2. **Clock skew.** The backend allows a small leeway on token expiry, but workstation clocks more than a minute off Keycloak's clock will see tokens rejected as expired. Compare the absolute expiry time in the agent's "Token fetched" log entry against the local system time; if these are close together (or worse, expiry is in the past) but tokens are still rejected, time sync is the likely cause.
+3. **Client disabled or deleted in Keycloak.** Verify the `SmartEM_Agent` client exists and is enabled.
+4. **Realm name mismatch.** The agent's `KEYCLOAK_REALM` must match the realm the backend trusts.
+5. **`azp` allow-list mismatch.** If the backend's allow-list does not include `SmartEM_Agent`, tokens issued to the agent will be rejected even though their signatures are valid.
+
+### Agent receives 401 after a period of normal operation
+
+Likely causes:
+
+1. **Secret rotated in Keycloak but configuration file not updated.** Update the file and restart the agent.
+2. **Client temporarily disabled.** Check Keycloak admin.
+
+### Agent cannot reach Keycloak
+
+If token fetch fails with a network error, verify the workstation can reach `${KEYCLOAK_URL}`. EPU workstations sit on isolated networks with proxy allow-lists; Keycloak must be on the allow-list. The same reachability requirement applies to the backend.
+
+### SSE stream disconnects and reconnects every few minutes
+
+This is expected behaviour around token expiry. If the disconnect interval matches the Keycloak access token lifespan (default 5 minutes), the agent is handling token rotation correctly. Disconnect intervals significantly shorter than the token lifespan suggest a different problem - typically network instability or a proxy timeout.
+
+## Related documentation
+
+- [ADR 0018: Authenticate SmartEM Agent against the backend using Keycloak client credentials](../decision-records/decisions/0018-smartem-agent-keycloak-auth.md)
+- [CLI Reference](cli-reference.md)
+- [Agent Deployment](deployment.md)
+- [Agent Troubleshooting](troubleshooting.md)
+- [Environment Variables](../operations/environment-variables.md)

--- a/docs/agent/cli-reference.md
+++ b/docs/agent/cli-reference.md
@@ -261,6 +261,7 @@ python -m smartem_agent watch [OPTIONS] PATH
 | `--session-id` | str | No | None | Session identifier for SSE connection |
 | `--sse-timeout` | int | No | 30 | SSE connection timeout in seconds |
 | `--heartbeat-interval` | int | No | 60 | Agent heartbeat interval in seconds (0 to disable) |
+| `--config` | str | No | _next to the agent executable_ | Path to the Keycloak authentication configuration file (see [Authentication](authentication.md)) |
 | `--verbose` | count | No | 0 | Verbosity level (see [Global Options](#global-options)) |
 
 ### Core Parameters
@@ -352,6 +353,24 @@ python -m smartem_agent watch /data --agent-id agent-01 --session-id session-123
 
 # Disable heartbeats (not recommended for production)
 python -m smartem_agent watch /data --agent-id agent-01 --session-id session-123 --heartbeat-interval 0
+```
+
+### Authentication Parameters
+
+#### --config
+**Type:** String (optional)
+**Default:** A file named `agent.env` located alongside the agent executable.
+**Description:** Path to the Keycloak authentication configuration file. The file is a dotenv-style file containing `KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, and `KEYCLOAK_CLIENT_SECRET`.
+
+The agent presents a Bearer token issued by Keycloak on every request to the backend. Missing or invalid configuration causes the agent to exit at startup. See [Authentication](authentication.md) for the full configuration, rotation, and troubleshooting guide.
+
+**Examples:**
+```bash
+# Use the default file location (next to the agent executable)
+python -m smartem_agent watch /data/microscopy
+
+# Use a custom configuration location
+python -m smartem_agent watch /data/microscopy --config /opt/smartem/agent.env
 ```
 
 ### Logging Parameters

--- a/docs/agent/deployment.md
+++ b/docs/agent/deployment.md
@@ -25,6 +25,12 @@ The agent operates in several modes depending on the timing of EPU data acquisit
 2. **Mid-acquisition mode**: Watcher launched _after_ EPU starts writing - combines parsing existing files with real-time monitoring
 3. **Post-acquisition mode**: Watcher launched _after_ EPU finishes - parses complete dataset then monitors for changes
 
+## Authentication
+
+The SmartEM Agent authenticates against the backend using Keycloak-issued Bearer tokens. Before deploying, prepare a configuration file with four values (`KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`). The agent reads this file from a default location alongside the executable or from a path provided via `--config`. Missing or invalid configuration causes the agent to exit at startup.
+
+See [Authentication](authentication.md) for the full configuration, rotation, and troubleshooting guide.
+
 ## Quick Start
 
 For comprehensive parameter documentation, see the [CLI Reference](cli-reference.md). For troubleshooting, see the [CLI Troubleshooting Guide](troubleshooting.md).

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -7,6 +7,7 @@ Documentation for the SmartEM Agent - the EPU filesystem watcher that runs on Wi
 
 cli-reference
 deployment
+authentication
 troubleshooting
 ```
 
@@ -20,3 +21,4 @@ troubleshooting
 ### Deployment
 
 - [Agent Deployment](deployment.md) - Running the agent on Windows workstations
+- [Authentication](authentication.md) - Configuring and operating Keycloak authentication

--- a/docs/agent/troubleshooting.md
+++ b/docs/agent/troubleshooting.md
@@ -121,7 +121,30 @@ inotifywait -m -r /data
 - Ensure files are completely written before processing
 - Consider filesystem-specific issues (NFS, network drives)
 
-### 3. API Connection Problems
+### 3. Authentication Errors (HTTP 401)
+
+The agent authenticates against the backend using Keycloak-issued Bearer tokens. A 401 from the backend, or a startup failure mentioning Keycloak configuration, points to one of:
+
+- **Missing or unreadable configuration file.** The agent expects a dotenv-style file with `KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, and `KEYCLOAK_CLIENT_SECRET`. Default location is alongside the agent executable; override with `--config`.
+- **Wrong client secret.** Verify against the Keycloak admin console.
+- **Workstation clock skew.** Tokens have a 5-minute lifespan with a small backend leeway. A workstation clock more than ~1 minute off Keycloak's clock will see tokens rejected as expired.
+- **Keycloak unreachable.** EPU workstations sit behind proxy allow-lists; Keycloak must be reachable from the workstation.
+- **`SmartEM_Agent` client disabled or deleted in the realm.**
+
+For full diagnosis and rotation procedures, see [Authentication](authentication.md). For quick checks:
+
+```bash
+# Verify the agent can reach Keycloak
+curl -v ${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/.well-known/openid-configuration
+
+# Manually obtain a token to test credentials
+curl -X POST \
+  -d "grant_type=client_credentials" \
+  -u "${KEYCLOAK_CLIENT_ID}:${KEYCLOAK_CLIENT_SECRET}" \
+  ${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token
+```
+
+### 4. API Connection Problems
 
 #### Error: `API at http://127.0.0.1:8000 is not reachable`
 
@@ -199,7 +222,7 @@ curl -X POST \
    - Verify database connectivity
    - Check for authentication issues
 
-### 4. Parsing and Validation Errors
+### 5. Parsing and Validation Errors
 
 #### Error: `Grid data dir is structurally invalid`
 
@@ -242,7 +265,7 @@ hexdump -C /path/to/EpuSession.dm | head -5
 - Ensure files are in expected format (not binary corrupted)
 - Look for encoding issues or special characters in paths
 
-### 5. Performance and Resource Issues
+### 6. Performance and Resource Issues
 
 #### Issue: High memory usage or slow processing
 
@@ -297,7 +320,7 @@ ulimit -n 4096
 echo "ulimit -n 4096" >> ~/.bashrc
 ```
 
-### 6. Logging and Output Issues
+### 7. Logging and Output Issues
 
 #### Issue: No log output or missing log files
 
@@ -331,7 +354,7 @@ python -m smartem_agent watch /data -vv     # DEBUG level
 python -m smartem_agent watch /data -v 2>&1 | tee output.log
 ```
 
-### 7. Signal Handling and Process Management
+### 8. Signal Handling and Process Management
 
 #### Issue: Process doesn't stop gracefully with Ctrl+C
 

--- a/docs/architecture/keycloak-spa-authentication.md
+++ b/docs/architecture/keycloak-spa-authentication.md
@@ -54,10 +54,16 @@ What the backend needs to add is **token validation** — a FastAPI dependency t
 
 ## Prerequisites
 
-A **Keycloak client registration** is required — someone needs to create a `smartem-frontend` client in the DLS Keycloak realm (`identity.diamond.ac.uk`) with:
+A **Keycloak client registration** is required — someone needs to create a `SmartEM` client in the DLS Keycloak realm (`identity.diamond.ac.uk`) with:
 
 - Client type: public (SPAs can't keep secrets)
 - Valid redirect URIs (the SPA's URL)
 - Web origins (for CORS)
 
 Without this, `keycloak-js` has nowhere to redirect to.
+
+## Local development
+
+For frontend development you do not need access to the DLS identity server. A self-contained Keycloak mock lives under `keycloak-mock/` in this repository and provides a `dls` realm with a pre-configured `SmartEM` client and seeded users.
+
+See [Local Keycloak for SmartEM frontend dev](../development/local-keycloak.md) for setup and integration with the frontend.

--- a/docs/backend/http-api-client.md
+++ b/docs/backend/http-api-client.md
@@ -12,6 +12,14 @@ data conversion utilities to convert between EPU data models and API request/res
 
 The SmartEM API Client is included with the SmartEM Decisions package, so no additional installation is required.
 
+## Authentication
+
+In deployed environments the SmartEM Decisions backend rejects unauthenticated requests with HTTP 401. Callers of `SmartEMAPIClient` are responsible for ensuring that the underlying `requests.Session` carries a valid Keycloak-issued Bearer token on every request.
+
+For the SmartEM Agent (the primary consumer of this client), token management is handled by an integrated Keycloak helper that fetches tokens via the OAuth 2.0 client_credentials grant, attaches them on every request, and refreshes on 401. See [Agent Authentication](../agent/authentication.md) for the operational details and [ADR 0018](../decision-records/decisions/0018-smartem-agent-keycloak-auth.md) for the architectural decision.
+
+For other callers (scripts, tests, ad-hoc tooling), obtain a token from Keycloak and attach it to the client's session headers before making requests.
+
 ## Basic Usage
 
 ### Importing the Client

--- a/docs/decision-records/decisions/0018-smartem-agent-keycloak-auth.md
+++ b/docs/decision-records/decisions/0018-smartem-agent-keycloak-auth.md
@@ -1,0 +1,94 @@
+# 18. Authenticate SmartEM Agent against the backend using Keycloak client credentials
+
+Date: 2026-05-19
+
+## Status
+
+Accepted
+
+## Context
+
+The SmartEM Decisions backend gates every non-exempt endpoint behind Keycloak Bearer-token validation (see DiamondLightSource/smartem-decisions#285). The SmartEM frontend authenticates against this through the standard OIDC authorization-code flow with PKCE (see DiamondLightSource/smartem-frontend#74).
+
+The SmartEM Agent runs unattended on EPU workstations near the microscope. It ingests EPU filesystem output and POSTs to the backend over HTTP/REST. It also receives ML recommendations from the backend via a long-running Server-Sent Events (SSE) connection. There is no browser at startup, no human present at the workstation, and no opportunity for interactive consent. The OIDC flow used by the frontend does not apply.
+
+Once the backend enforces token validation in any deployed environment, an unauthenticated agent immediately fails. The agent therefore needs a service-to-service authentication path that:
+
+- Reuses the existing JWT validation already shipped on the backend, avoiding a second parallel auth system.
+- Operates without human interaction at startup.
+- Is operationally feasible for unattended workstations deployed across the facility.
+- Has a clear hardening path for future requirements such as per-agent revocation.
+
+DiamondLightSource/smartem-decisions#284 tracks the open question and its initial analysis.
+
+## Decision
+
+The SmartEM Agent authenticates against Keycloak using the OAuth 2.0 **client_credentials** grant (RFC 6749 §4.4), with a dedicated Keycloak client `SmartEM_Agent` configured for confidential client authentication using a shared client secret (`clientAuthenticatorType: "client-secret"`, `serviceAccountsEnabled: true`).
+
+The existing browser-facing Keycloak client previously named `SmartEM` is renamed `SmartEM_User` so that the user-versus-agent distinction is explicit in the realm.
+
+The agent reads its Keycloak configuration (URL, realm, client ID, client secret) from a dotenv-style file. The default location is alongside the agent executable; an optional `--config` CLI parameter overrides the path. No values are baked into the agent binary at build time, so secret rotation requires no rebuild.
+
+The agent obtains a Bearer token by POSTing to `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token` with `grant_type=client_credentials` and presents the resulting RS256 JWT on every request to the backend. The backend's existing `verify_token` dependency validates the signature against the realm's JWKS. The backend additionally enforces that the token's `azp` (authorised party) claim is one of an allow-listed set: `SmartEM_User` for browser-originated requests, `SmartEM_Agent` for agent-originated requests.
+
+Both ends fail closed. Missing or invalid Keycloak configuration causes the agent to exit non-zero at startup. The backend returns HTTP 401 to any request without a valid token. There is no fallback to unauthenticated operation.
+
+A future upgrade to **private_key_jwt** client authentication (RFC 7523) is planned, once the client_credentials flow is stable in deployed environments. That upgrade replaces the shared secret with a per-agent keypair registered as a public key against the Keycloak client. It leaves the backend, the agent's request-handling code, and the operational rollout structure unchanged - only the agent's token-fetch step and the Keycloak client's `clientAuthenticatorType` differ. This forward path is documented here so the v1 design choices do not foreclose it.
+
+## Alternatives Considered
+
+Five options were evaluated before settling on client_credentials.
+
+| Option | Summary | Why not |
+|--------|---------|---------|
+| **JWT client authentication** (private_key_jwt) | Same OAuth grant as client_credentials but the agent signs a JWT with a private key instead of presenting a shared secret. | The right destination state, but introduces per-agent key distribution and lifecycle management before the basic flow is proven in production. Deferred as the v2 upgrade. |
+| **Mutual TLS** | The ingress requires client certificates; the backend trusts the certificate subject. | Introduces a second authentication system on the backend running alongside the existing JWT validation. Doubles the auth surface, complicates testing, and does not compose with the work in #285. |
+| **Static API key** | The backend accepts a long-lived secret in a custom header. | Reinvents authentication. No rotation story without redeploying both sides. No expiry, no `azp` claim, no claim-based attribution. Adds a parallel auth path. |
+| **Exempt agent endpoints** | The agent's ingestion endpoints are added to the backend's `EXEMPT_PATHS`; network policy is relied upon for protection. | "Internal-only" stays internal-only only when actively enforced. On shared clusters this is brittle. Loses per-agent attribution. The data-ingestion endpoints are precisely where authenticated provenance is most valuable. |
+
+The client_credentials choice was preferred because:
+
+- It is the only option that reuses the JWT validation on the backend without structural change.
+- It carries an `azp` claim, giving the backend a free hook for distinguishing agents from users and for future authorisation refinements.
+- It has a clean upgrade path to private_key_jwt without rewriting agent code.
+- Shared-secret distribution is operationally appropriate for the current scale: one client per agent population, deployed to trusted hosts by DLS infrastructure. The downside - no per-agent revocation without rotating the population secret - is acceptable for v1 and is the explicit motivation for the planned v2 upgrade.
+
+## Consequences
+
+### Keycloak
+
+The realm gains a confidential client `SmartEM_Agent` with a generated secret. The browser-facing client is renamed from `SmartEM` to `SmartEM_User`. Both changes are required in the local mock realm (`smartem-devtools/keycloak-mock/dls-realm.json`) and in the real DLS Keycloak realm; the latter is requested via Jira from the Keycloak administrators.
+
+For the mock realm, the agent client secret is hard-coded as `dev-agent-secret` to allow agents to self-configure from a checked-in development configuration. This value has no security significance outside development.
+
+### Backend
+
+The backend gains `azp` claim enforcement via a configuration value (allow-list of accepted client IDs). Tokens whose `azp` is not in the allow-list are rejected. The allow-list is populated with `SmartEM_User` and `SmartEM_Agent`. Adding further entries (for future service clients) is a configuration change with no code impact.
+
+### Agent
+
+The agent gains a small Keycloak token-management component: a single class responsible for fetching tokens via client_credentials, caching them in memory, refreshing proactively shortly before expiry, and refreshing on demand when a request returns 401. This component is composed into the existing `SmartEMAPIClient` so that all HTTP requests (including the long-running SSE connection) attach a Bearer token through the shared `requests.Session` already used by every API call.
+
+The agent reads its four Keycloak configuration values from a dotenv-style file. Default path is alongside the agent executable; a `--config` CLI parameter overrides. Missing or unreadable configuration causes the agent to exit at startup with a clear error.
+
+### Operations
+
+Secret rotation under v1 is a Keycloak admin action followed by a configuration update on each agent workstation and an agent restart. At the current scale this is manual; the operational scaling cost is one of the motivations for the planned move to private_key_jwt.
+
+The shared-secret model means revoking access for one compromised workstation requires rotating the population secret. This is an accepted trade-off for v1 and the principal motivation for v2.
+
+Configuration file permissions are the responsibility of the deployer. Initial guidance is OS-level access control restricting read to the agent's runtime user. Storage hardening via OS-native secret stores is a future iteration if and when the threat model warrants it.
+
+### Observability
+
+The agent emits structured log entries on token fetch and refresh, recording the absolute expiry time and the local system time. Tokens themselves are never logged. 401 responses from the backend trigger a single token refresh and retry; repeated 401s after refresh are surfaced as errors with enough context to diagnose clock skew, secret mismatch, or revocation.
+
+### Documentation
+
+This ADR is accompanied by an operational guide at `docs/agent/authentication.md` that covers configuration, secret rotation, local development against the Keycloak mock, and 401 troubleshooting.
+
+### Follow-ups
+
+- Implementation issue to be opened tracking the agent-side `KeycloakClient` component, the backend `azp` allow-list configuration, and end-to-end testing against the mock realm.
+- Migration to private_key_jwt to be reopened as a separate ADR once operational experience with client_credentials has accumulated.
+- Jira request to the DLS Keycloak administrators for the equivalent changes on the production realm.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -9,6 +9,7 @@ contributing
 tools
 generate-docs
 e2e-simulation
+local-keycloak
 github-labels
 ```
 
@@ -22,6 +23,7 @@ github-labels
 
 - [Development Tools](tools.md) - Utility tools for development, testing, and maintenance
 - [E2E Simulation](e2e-simulation.md) - End-to-end development simulation setup
+- [Local Keycloak](local-keycloak.md) - Self-contained Keycloak mock for frontend auth development
 
 ### Documentation and CI/CD
 

--- a/docs/development/local-keycloak.md
+++ b/docs/development/local-keycloak.md
@@ -53,7 +53,7 @@ The `keycloak-mock/kustomization.yaml` is referenced as a base by `k8s/environme
 The Keycloak service is reachable as:
 
 - `http://keycloak-service:8080` inside the cluster (ClusterIP);
-- `http://<node-ip>:30080` from outside (NodePort).
+- `http://<node-ip>:30090` from outside (NodePort).
 
 To deploy Keycloak alone — for example, on an existing cluster not managed by `dev-k8s.sh`:
 
@@ -89,7 +89,7 @@ VITE_KEYCLOAK_CLIENT_ID=SmartEM
 VITE_AUTH_ENABLED=true
 ```
 
-For the k8s form without port-forward, substitute `http://<node-ip>:30080` for the URL. With a single-node k3s cluster, `node-ip` is the host's IP.
+For the k8s form without port-forward, substitute `http://<node-ip>:30090` for the URL. With a single-node k3s cluster, `node-ip` is the host's IP.
 
 After changing `.env.local`, restart the Vite dev server (env values are read at startup).
 

--- a/docs/development/local-keycloak.md
+++ b/docs/development/local-keycloak.md
@@ -1,0 +1,122 @@
+# Local Keycloak for SmartEM frontend dev
+
+The SmartEM frontend authenticates against Keycloak. For local development there is a self-contained Keycloak mock under `keycloak-mock/` in this repository. It is offered in two equivalent forms — Docker Compose for quick standalone use, and Kubernetes manifests integrated with the rest of the dev stack — both reading from the same realm export.
+
+The architecture of the auth flow itself is documented in [Keycloak SPA authentication](../architecture/keycloak-spa-authentication.md). This page is the operational counterpart: what to run, when, and how to point the frontend at it.
+
+## Why a mock
+
+The DLS identity servers (`identity.diamond.ac.uk`, `identity-test.diamond.ac.uk`) require explicit registration of every client and origin allowed to authenticate. Local development on `http://localhost:5173` is not registered by default, and getting it added is an admin task that has to be repeated whenever the dev port changes or a new developer joins.
+
+Running a local Keycloak instead:
+
+- removes the round-trip with whoever administers the DLS realm;
+- gives every developer the same realm config (checked into version control);
+- works offline;
+- is deterministic — no stale tokens from yesterday's session, no realm config drift.
+
+The mock realm is **not** intended to be representative of the production DLS realm beyond what the frontend needs (client, scopes, a couple of users, a `fedId` claim mapper). It is a development convenience, not a staging environment.
+
+## Which form to use
+
+| Use Compose when… | Use Kubernetes when… |
+|---|---|
+| You only need the frontend running, not the backend stack. | You're already running the dev k3s stack (`./scripts/k8s/dev-k8s.sh up`) and want auth alongside it. |
+| You want the fastest possible cycle (`docker compose up -d` ≈ 20 s). | You want to match how the rest of the dev stack is deployed. |
+| You're debugging Keycloak itself and want minimal moving parts. | You want to validate behaviour close to production deployment shape. |
+
+Both forms read from the same `keycloak-mock/dls-realm.json`, so any change you make to the realm export takes effect for either on next apply.
+
+## Compose form
+
+From `smartem-devtools/`:
+
+```bash
+cd keycloak-mock
+docker compose up -d
+```
+
+Keycloak starts on `http://localhost:8080` in dev mode, imports the `dls` realm from `dls-realm.json`, and is ready in ~20 s. Bootstrap admin credentials are `admin` / `admin` (admin console at `http://localhost:8080`).
+
+State is **not** persisted between container lifecycles — each `up` reimports the realm. That keeps the mock deterministic; if you need to capture interactive admin changes, export the realm via `kc.sh export` from inside the running container and replace `dls-realm.json`.
+
+Tear down with `docker compose down`.
+
+## Kubernetes form
+
+The `keycloak-mock/kustomization.yaml` is referenced as a base by `k8s/environments/development/kustomization.yaml`. Bringing up the dev stack brings up Keycloak alongside it:
+
+```bash
+./scripts/k8s/dev-k8s.sh up
+```
+
+The Keycloak service is reachable as:
+
+- `http://keycloak-service:8080` inside the cluster (ClusterIP);
+- `http://<node-ip>:30080` from outside (NodePort).
+
+To deploy Keycloak alone — for example, on an existing cluster not managed by `dev-k8s.sh`:
+
+```bash
+kubectl apply -k keycloak-mock
+```
+
+The kustomization generates a ConfigMap from `dls-realm.json` and mounts it at `/opt/keycloak/data/import`. Updating the realm requires re-applying the kustomization so the ConfigMap is regenerated, and either deleting the pod or doing a `kubectl rollout restart deployment/keycloak`.
+
+## Realm contents
+
+The realm export at `keycloak-mock/dls-realm.json` defines:
+
+- **Realm**: `dls` — matches `VITE_KEYCLOAK_REALM` defaults so no env change needed.
+- **Client**: `SmartEM` — public client, standard flow, PKCE S256.
+- **Valid redirect URIs**: `http://localhost:5173/*` and `http://localhost:5174/*` (the smartem app and legacy app dev ports).
+- **Web origins**: same hosts (required for silent SSO iframe checks once that's enabled in the frontend).
+- **Custom claim mapper**: `fedId` — the AuthProvider in the SmartEM frontend reads `idTokenParsed.fedId`. The mapper picks up the user attribute and emits it as an ID-token claim.
+- **Seeded users**:
+  - `devuser` / `devpass` — generic, fedId `dev12345`.
+  - `valuser` / `valpass` — for Val Redchenko, fedId `val99999`.
+
+The mock does not implement the full DLS user model (groups, roles, federated identity). Add more users or roles by editing `dls-realm.json` directly.
+
+## Pointing the frontend at it
+
+In `smartem-frontend/apps/smartem/.env.local`:
+
+```env
+VITE_KEYCLOAK_URL=http://localhost:8080      # compose, or k8s with port-forward
+VITE_KEYCLOAK_REALM=dls
+VITE_KEYCLOAK_CLIENT_ID=SmartEM
+VITE_AUTH_ENABLED=true
+```
+
+For the k8s form without port-forward, substitute `http://<node-ip>:30080` for the URL. With a single-node k3s cluster, `node-ip` is the host's IP.
+
+After changing `.env.local`, restart the Vite dev server (env values are read at startup).
+
+## Disabling auth entirely
+
+For UI work that doesn't need to exercise auth, set `VITE_AUTH_ENABLED=false`. The `AuthGate` short-circuits and the SPA renders without contacting Keycloak at all. This is a deliberately separate path from "Keycloak is unavailable" — the latter is an error state to recover from, the former is a development convenience.
+
+## Editing the realm
+
+Modify `dls-realm.json` directly. Both forms read from the same file. After editing:
+
+- **Compose**: `docker compose down && docker compose up -d` — Keycloak reimports on startup.
+- **Kubernetes**: `kubectl apply -k keycloak-mock` (regenerates the ConfigMap with a new hash if `disableNameSuffixHash` is removed) followed by `kubectl rollout restart deployment/keycloak -n smartem-decisions`.
+
+For interactive admin changes you want to keep, use the admin console, then export from inside the container:
+
+```bash
+docker exec smartem-keycloak \
+  /opt/keycloak/bin/kc.sh export \
+  --realm dls \
+  --dir /tmp/export \
+  --users realm_file
+docker cp smartem-keycloak:/tmp/export/dls-realm.json ./dls-realm.json
+```
+
+## Limits and non-goals
+
+- **Not for staging or production.** Dev mode, HTTP only, bootstrap admin credentials, no TLS, no persistent storage.
+- **Not a faithful DLS realm replica.** Groups, federated identity, fine-grained roles, custom themes — all absent. The mock has just enough surface for the frontend's `AuthProvider` to function end-to-end.
+- **Realm export drift.** If the production DLS realm changes its claim shape (new mappers, scope changes), the mock won't track that automatically. Treat it as a snapshot, not a mirror.

--- a/docs/operations/environment-variables.md
+++ b/docs/operations/environment-variables.md
@@ -313,6 +313,21 @@ set -a && source .env && set +a
 env | grep POSTGRES
 ```
 
+## Agent Keycloak Configuration
+
+The SmartEM Agent uses a separate dotenv-style configuration file for Keycloak authentication, distinct from the backend `.env` files described above. This decoupling reflects that the agent runs on EPU workstations rather than inside the Kubernetes cluster.
+
+| Variable | Purpose |
+|----------|---------|
+| `KEYCLOAK_URL` | Base URL of the Keycloak server |
+| `KEYCLOAK_REALM` | Realm name (e.g. `dls`) |
+| `KEYCLOAK_CLIENT_ID` | Client identifier (`SmartEM_Agent` in normal operation) |
+| `KEYCLOAK_CLIENT_SECRET` | Confidential client secret |
+
+The agent reads these from a configuration file located either alongside the agent executable (default) or at a path passed via `--config`. All four are mandatory; missing or empty values cause the agent to exit at startup.
+
+For configuration, rotation, and troubleshooting, see [Agent Authentication](../agent/authentication.md). For the architectural decision, see [ADR 0018](../decision-records/decisions/0018-smartem-agent-keycloak-auth.md).
+
 ## Related Documentation
 
 - [Run Backend Services](../backend/api-server.md) - Starting backend API and consumer
@@ -320,3 +335,4 @@ env | grep POSTGRES
 - [Deploy to Kubernetes](kubernetes.md) - K8s deployment guide
 - [Manage Kubernetes Secrets](kubernetes-secrets.md) - Sealed Secrets and security
 - [Database Migrations](../backend/database.md) - Alembic migration workflow
+- [Agent Authentication](../agent/authentication.md) - Keycloak configuration for the agent

--- a/env-examples/.env.example.k8s.development
+++ b/env-examples/.env.example.k8s.development
@@ -27,3 +27,13 @@ ADMINER_PORT=8080
 # CORS configuration (comma-separated list of allowed origins)
 # Use "*" for development to allow all origins
 CORS_ALLOWED_ORIGINS=*
+
+# Keycloak OIDC integration (in-cluster mock).
+# KEYCLOAK_VERIFY_ISS=false because tokens are minted with the browser-facing
+# URL (localhost:30090) while the pod fetches JWKS via in-cluster DNS
+# (keycloak-service:8080).
+KEYCLOAK_AUTH_REQUIRED=false
+KEYCLOAK_URL=http://keycloak-service:8080
+KEYCLOAK_REALM=dls
+KEYCLOAK_CLIENT_ID=SmartEM
+KEYCLOAK_VERIFY_ISS=false

--- a/env-examples/.env.example.k8s.staging
+++ b/env-examples/.env.example.k8s.staging
@@ -28,3 +28,12 @@ ADMINER_PORT=8080
 # For staging, specify exact origins for security
 # Example: "https://staging.example.com,https://staging-app.example.com"
 CORS_ALLOWED_ORIGINS=https://staging.example.com
+
+# Keycloak OIDC integration
+# KEYCLOAK_AUTH_REQUIRED=true makes the backend reject non-exempt requests
+# without a valid Bearer token. KEYCLOAK_URL must reach the realm host.
+KEYCLOAK_AUTH_REQUIRED=true
+KEYCLOAK_URL=https://identity-test.diamond.ac.uk
+KEYCLOAK_REALM=dls
+KEYCLOAK_CLIENT_ID=SmartEM
+KEYCLOAK_VERIFY_ISS=true

--- a/k8s/environments/development/configmap.yaml
+++ b/k8s/environments/development/configmap.yaml
@@ -14,3 +14,13 @@ data:
   HTTP_API_PORT: "8000"
   ADMINER_PORT: "8080"
   CORS_ALLOWED_ORIGINS: "*"
+  # Keycloak OIDC integration. Points at the in-cluster keycloak-mock
+  # service. KEYCLOAK_VERIFY_ISS=false because tokens are issued with the
+  # browser-facing URL (localhost:30090) while the pod fetches JWKS via
+  # in-cluster DNS (keycloak-service:8080) - signing key matches but the
+  # iss claim does not.
+  KEYCLOAK_AUTH_REQUIRED: "false"
+  KEYCLOAK_URL: "http://keycloak-service:8080"
+  KEYCLOAK_REALM: "dls"
+  KEYCLOAK_CLIENT_ID: "SmartEM"
+  KEYCLOAK_VERIFY_ISS: "false"

--- a/k8s/environments/development/kustomization.yaml
+++ b/k8s/environments/development/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - adminer.yaml
 - smartem-http-api.yaml
 - smartem-worker.yaml
+- ../../../keycloak-mock
 
 namePrefix: ""
 namespace: smartem-decisions

--- a/k8s/environments/staging/configmap.yaml
+++ b/k8s/environments/staging/configmap.yaml
@@ -14,3 +14,11 @@ data:
   HTTP_API_PORT: "8000"
   ADMINER_PORT: "8080"
   CORS_ALLOWED_ORIGINS: "https://staging.example.com"
+  # Keycloak OIDC integration. KEYCLOAK_AUTH_REQUIRED=true rejects all
+  # non-exempt requests that don't carry a valid Bearer token. Defaults
+  # below target the DLS test realm; override per environment via .env.
+  KEYCLOAK_AUTH_REQUIRED: "true"
+  KEYCLOAK_URL: "https://identity-test.diamond.ac.uk"
+  KEYCLOAK_REALM: "dls"
+  KEYCLOAK_CLIENT_ID: "SmartEM"
+  KEYCLOAK_VERIFY_ISS: "true"

--- a/keycloak-mock/README.md
+++ b/keycloak-mock/README.md
@@ -46,7 +46,7 @@ To deploy keycloak alone (e.g. on an existing cluster):
 kubectl apply -k keycloak-mock
 ```
 
-Once running, the Keycloak service is reachable inside the cluster at `http://keycloak-service:8080` (ClusterIP) and from outside at `http://<node-ip>:30080` (NodePort).
+Once running, the Keycloak service is reachable inside the cluster at `http://keycloak-service:8080` (ClusterIP) and from outside at `http://<node-ip>:30090` (NodePort). (30090 not 30080 because the SmartEM HTTP API service already owns 30080 in the dev environment.)
 
 ## Pointing the frontend at it
 
@@ -55,7 +55,7 @@ In `smartem-frontend/apps/smartem/.env.local`:
 ```env
 VITE_KEYCLOAK_URL=http://localhost:8080      # compose / port-forward
 # or
-VITE_KEYCLOAK_URL=http://<node-ip>:30080     # k8s NodePort
+VITE_KEYCLOAK_URL=http://<node-ip>:30090     # k8s NodePort
 VITE_KEYCLOAK_REALM=dls
 VITE_KEYCLOAK_CLIENT_ID=SmartEM
 VITE_AUTH_ENABLED=true

--- a/keycloak-mock/README.md
+++ b/keycloak-mock/README.md
@@ -1,0 +1,70 @@
+# Keycloak mock
+
+Local Keycloak instance for developing and testing SmartEM frontend authentication without depending on the DLS identity server.
+
+Two deployment forms; pick whichever fits your workflow.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `dls-realm.json` | Realm export. Single source of truth, consumed by both forms. Realm `dls`, client `SmartEM`, two seeded users. |
+| `docker-compose.yml` | Standalone Compose deployment. Fastest path to a running Keycloak. |
+| `keycloak.yaml` | Kubernetes Deployment + Services. |
+| `kustomization.yaml` | Kustomize config; loads the realm JSON as a ConfigMap. Referenced as a base by `k8s/environments/development/kustomization.yaml`, also works standalone. |
+
+## Realm contents
+
+- **Realm**: `dls`
+- **Client**: `SmartEM` (public, PKCE S256, standard flow)
+- **Redirect URIs**: `http://localhost:5173/*`, `http://localhost:5174/*`
+- **Web Origins**: same hosts
+- **Custom claim**: `fedId` (protocol mapper from user attribute), to mirror DLS realm claims
+- **Users**:
+  - `devuser` / `devpass` (Dev User, fedId `dev12345`)
+  - `valuser` / `valpass` (Val Redchenko, fedId `val99999`)
+
+## Compose
+
+```bash
+docker compose up -d
+# admin console: http://localhost:8080  (admin / admin)
+# realm endpoint: http://localhost:8080/realms/dls
+```
+
+State is **not persisted** between container restarts — each `up` reimports the realm. That's deliberate for a mock: deterministic startup, no stale state.
+
+To tear down: `docker compose down`.
+
+## Kubernetes
+
+Comes up automatically with the rest of the dev stack via `./scripts/k8s/dev-k8s.sh`. The keycloak base is wired into `k8s/environments/development/kustomization.yaml`.
+
+To deploy keycloak alone (e.g. on an existing cluster):
+
+```bash
+kubectl apply -k keycloak-mock
+```
+
+Once running, the Keycloak service is reachable inside the cluster at `http://keycloak-service:8080` (ClusterIP) and from outside at `http://<node-ip>:30080` (NodePort).
+
+## Pointing the frontend at it
+
+In `smartem-frontend/apps/smartem/.env.local`:
+
+```env
+VITE_KEYCLOAK_URL=http://localhost:8080      # compose / port-forward
+# or
+VITE_KEYCLOAK_URL=http://<node-ip>:30080     # k8s NodePort
+VITE_KEYCLOAK_REALM=dls
+VITE_KEYCLOAK_CLIENT_ID=SmartEM
+VITE_AUTH_ENABLED=true
+```
+
+Then `npm run dev:smartem` from the smartem-frontend repo root.
+
+## Editing the realm
+
+Modify `dls-realm.json` directly. Both Compose and Kustomize pick it up on next apply. For interactive admin (UI changes you want to capture), use the admin console at `:8080`, export the realm via `kc.sh export`, and replace `dls-realm.json`.
+
+See [Local Keycloak for SmartEM frontend dev](../docs/development/local-keycloak.md) for the wider context, including which workflow to choose and the auth flow integration.

--- a/keycloak-mock/dls-realm.json
+++ b/keycloak-mock/dls-realm.json
@@ -14,7 +14,7 @@
   "ssoSessionMaxLifespan": 36000,
   "clients": [
     {
-      "clientId": "SmartEM",
+      "clientId": "SmartEM_User",
       "name": "SmartEM Frontend",
       "enabled": true,
       "publicClient": true,
@@ -60,6 +60,24 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "SmartEM_Agent",
+      "name": "SmartEM Agent",
+      "description": "Service account client for SmartEM Agents running on EPU workstations. Uses the OAuth 2.0 client_credentials grant to obtain access tokens for backend API calls.",
+      "enabled": true,
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "dev-agent-secret",
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "implicitFlowEnabled": false,
+      "serviceAccountsEnabled": true,
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "roles"
+      ]
     }
   ],
   "users": [
@@ -77,25 +95,6 @@
         {
           "type": "password",
           "value": "devpass",
-          "temporary": false
-        }
-      ],
-      "realmRoles": ["default-roles-dls"]
-    },
-    {
-      "username": "valuser",
-      "enabled": true,
-      "emailVerified": true,
-      "firstName": "Val",
-      "lastName": "Redchenko",
-      "email": "lazyval@gmail.com",
-      "attributes": {
-        "fedId": ["val99999"]
-      },
-      "credentials": [
-        {
-          "type": "password",
-          "value": "valpass",
           "temporary": false
         }
       ],

--- a/keycloak-mock/dls-realm.json
+++ b/keycloak-mock/dls-realm.json
@@ -1,0 +1,105 @@
+{
+  "realm": "dls",
+  "enabled": true,
+  "displayName": "Diamond Light Source (local dev)",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "sslRequired": "none",
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "clients": [
+    {
+      "clientId": "SmartEM",
+      "name": "SmartEM Frontend",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "implicitFlowEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:5173/*",
+        "http://localhost:5174/*"
+      ],
+      "webOrigins": [
+        "http://localhost:5173",
+        "http://localhost:5174"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:5173/*##http://localhost:5174/*"
+      },
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles",
+        "web-origins"
+      ],
+      "optionalClientScopes": [
+        "offline_access"
+      ],
+      "protocolMappers": [
+        {
+          "name": "fedId",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "fedId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "fedId",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "devuser",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dev",
+      "lastName": "User",
+      "email": "devuser@diamond.ac.uk",
+      "attributes": {
+        "fedId": ["dev12345"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "devpass",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["default-roles-dls"]
+    },
+    {
+      "username": "valuser",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Val",
+      "lastName": "Redchenko",
+      "email": "lazyval@gmail.com",
+      "attributes": {
+        "fedId": ["val99999"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "valpass",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["default-roles-dls"]
+    }
+  ]
+}

--- a/keycloak-mock/docker-compose.yml
+++ b/keycloak-mock/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    container_name: smartem-keycloak
+    command:
+      - start-dev
+      - --import-realm
+      - --http-port=8080
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+      KC_HOSTNAME_STRICT: "false"
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./dls-realm.json:/opt/keycloak/data/import/dls-realm.json:ro
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'exec 3<>/dev/tcp/localhost/9000 && echo -e "GET /health/ready HTTP/1.1\r\nHost: localhost\r\n\r\n" >&3 && grep -q "UP" <&3'
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s

--- a/keycloak-mock/keycloak.yaml
+++ b/keycloak-mock/keycloak.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  namespace: smartem-decisions
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      tolerations:
+      - key: node.kubernetes.io/disk-pressure
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: keycloak
+        image: quay.io/keycloak/keycloak:26.0
+        args:
+        - start-dev
+        - --import-realm
+        - --http-port=8080
+        env:
+        - name: KC_BOOTSTRAP_ADMIN_USERNAME
+          value: admin
+        - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+          value: admin
+        - name: KC_HEALTH_ENABLED
+          value: "true"
+        - name: KC_HOSTNAME_STRICT
+          value: "false"
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: management
+          containerPort: 9000
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: management
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: management
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          failureThreshold: 6
+        volumeMounts:
+        - name: realm-import
+          mountPath: /opt/keycloak/data/import
+          readOnly: true
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "200m"
+          limits:
+            memory: "1Gi"
+            cpu: "1000m"
+      volumes:
+      - name: realm-import
+        configMap:
+          name: keycloak-realm
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-service
+  namespace: smartem-decisions
+spec:
+  selector:
+    app: keycloak
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-external
+  namespace: smartem-decisions
+spec:
+  selector:
+    app: keycloak
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    nodePort: 30080
+  type: NodePort

--- a/keycloak-mock/keycloak.yaml
+++ b/keycloak-mock/keycloak.yaml
@@ -98,5 +98,5 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
-    nodePort: 30080
+    nodePort: 30090
   type: NodePort

--- a/keycloak-mock/kustomization.yaml
+++ b/keycloak-mock/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: smartem-decisions
+
+resources:
+- keycloak.yaml
+
+configMapGenerator:
+- name: keycloak-realm
+  files:
+  - dls-realm.json
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+commonLabels:
+  app.kubernetes.io/part-of: smartem-keycloak-mock

--- a/scripts/k8s/dev-k8s.sh
+++ b/scripts/k8s/dev-k8s.sh
@@ -302,12 +302,19 @@ ensure_app_configmap() {
     local http_api_port="${HTTP_API_PORT:-}"
     local adminer_port="${ADMINER_PORT:-}"
     local cors_allowed_origins="${CORS_ALLOWED_ORIGINS:-}"
+    local keycloak_auth_required="${KEYCLOAK_AUTH_REQUIRED:-}"
+    local keycloak_url="${KEYCLOAK_URL:-}"
+    local keycloak_realm="${KEYCLOAK_REALM:-}"
+    local keycloak_client_id="${KEYCLOAK_CLIENT_ID:-}"
+    local keycloak_verify_iss="${KEYCLOAK_VERIFY_ISS:-}"
 
     # Check if any env vars are set
     local has_env_overrides=false
     if [[ -n "$postgres_host" ]] || [[ -n "$postgres_port" ]] || [[ -n "$postgres_db" ]] || \
        [[ -n "$rabbitmq_host" ]] || [[ -n "$rabbitmq_port" ]] || \
-       [[ -n "$http_api_port" ]] || [[ -n "$adminer_port" ]] || [[ -n "$cors_allowed_origins" ]]; then
+       [[ -n "$http_api_port" ]] || [[ -n "$adminer_port" ]] || [[ -n "$cors_allowed_origins" ]] || \
+       [[ -n "$keycloak_auth_required" ]] || [[ -n "$keycloak_url" ]] || [[ -n "$keycloak_realm" ]] || \
+       [[ -n "$keycloak_client_id" ]] || [[ -n "$keycloak_verify_iss" ]]; then
         has_env_overrides=true
     fi
 
@@ -331,11 +338,17 @@ ensure_app_configmap() {
     http_api_port="${http_api_port:-8000}"
     adminer_port="${adminer_port:-8080}"
     cors_allowed_origins="${cors_allowed_origins:-*}"
+    keycloak_auth_required="${keycloak_auth_required:-false}"
+    keycloak_url="${keycloak_url:-http://keycloak-service:8080}"
+    keycloak_realm="${keycloak_realm:-dls}"
+    keycloak_client_id="${keycloak_client_id:-SmartEM}"
+    keycloak_verify_iss="${keycloak_verify_iss:-false}"
 
     log_info "Creating application ConfigMap for environment: $DEPLOY_ENV"
     log_info "POSTGRES_HOST=$postgres_host, POSTGRES_PORT=$postgres_port, POSTGRES_DB=$postgres_db"
     log_info "RABBITMQ_HOST=$rabbitmq_host, RABBITMQ_PORT=$rabbitmq_port"
     log_info "HTTP_API_PORT=$http_api_port, CORS_ALLOWED_ORIGINS=$cors_allowed_origins"
+    log_info "KEYCLOAK_AUTH_REQUIRED=$keycloak_auth_required, KEYCLOAK_URL=$keycloak_url, KEYCLOAK_REALM=$keycloak_realm"
 
     kubectl create configmap smartem-config \
         --from-literal=POSTGRES_HOST="$postgres_host" \
@@ -346,6 +359,11 @@ ensure_app_configmap() {
         --from-literal=HTTP_API_PORT="$http_api_port" \
         --from-literal=ADMINER_PORT="$adminer_port" \
         --from-literal=CORS_ALLOWED_ORIGINS="$cors_allowed_origins" \
+        --from-literal=KEYCLOAK_AUTH_REQUIRED="$keycloak_auth_required" \
+        --from-literal=KEYCLOAK_URL="$keycloak_url" \
+        --from-literal=KEYCLOAK_REALM="$keycloak_realm" \
+        --from-literal=KEYCLOAK_CLIENT_ID="$keycloak_client_id" \
+        --from-literal=KEYCLOAK_VERIFY_ISS="$keycloak_verify_iss" \
         --namespace="$NAMESPACE"
 
     log_success "Application ConfigMap created with .env overrides"


### PR DESCRIPTION
## Motivation

Two things had to land together:

1. The frontend Keycloak integration in DiamondLightSource/smartem-frontend#74 had no local-dev story — `http://localhost:5173` isn't in the `SmartEM` client's redirect URIs on `identity-test.diamond.ac.uk`, and getting it added is an admin round-trip per port and per developer.
2. Once DiamondLightSource/smartem-decisions starts validating Bearer tokens, the backend ConfigMap and `dev-k8s.sh` need to carry the same `KEYCLOAK_*` settings so the pod can fetch JWKS in-cluster.

This PR covers both: a self-contained Keycloak mock for the frontend, and the env-wiring that lets the backend point at it (or at the real DLS realm in staging) without YAML surgery.

## What's included

### Self-contained Keycloak mock (`keycloak-mock/`)

Two equivalent deployment forms, both reading from one realm export:

- `dls-realm.json` — single source of truth. Realm `dls`, public client `SmartEM` with PKCE S256, `localhost:5173` and `localhost:5174` in redirect URIs and Web Origins, custom `fedId` claim mapper to mirror DLS realm claims, two seeded users (`devuser`/`devpass`, `valuser`/`valpass`).
- `docker-compose.yml` — Compose form, fastest standalone cycle (~20 s).
- `keycloak.yaml` + `kustomization.yaml` — Kubernetes Deployment + Services + kustomize `configMapGenerator` for the realm JSON.

The Kustomize form is wired into `k8s/environments/development/kustomization.yaml`, so `./scripts/k8s/dev-k8s.sh up` brings up Keycloak alongside Postgres, RabbitMQ, etc. The Compose form is independent and useful when only the frontend is needed.

### Backend Keycloak env wiring

`smartem-config` ConfigMap (both `development` and `staging` overlays) gains:

- `KEYCLOAK_AUTH_REQUIRED` — master switch consumed by the backend (defaults: `false` in dev, `true` in staging)
- `KEYCLOAK_URL` — dev points at `http://keycloak-service:8080` (in-cluster DNS); staging points at `https://identity-test.diamond.ac.uk`
- `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_VERIFY_ISS`

Dev has `KEYCLOAK_VERIFY_ISS=false` because tokens are minted with the browser-facing URL (`localhost:30090`) while the pod reaches Keycloak via in-cluster DNS — signing key is identical but `iss` strings differ. Staging has `iss` verification on.

`dev-k8s.sh ensure_app_configmap()` reads the five vars from the environment and bakes them into the dynamically-generated ConfigMap. Operators only need to edit `.env.k8s.<env>` — corresponding examples in `env-examples/` are updated.

### Port-conflict fix (`fix(keycloak-mock): move NodePort to 30090`)

The development environment's `smartem-http-api-service` already claimed NodePort `30080`. Applying the dev kustomization with the keycloak mock therefore failed with a port conflict. Moved `keycloak-external` to `30090` and updated the three doc references.

## Docs

- `docs/development/local-keycloak.md` — full how-to (when to use which form, how to point the frontend at it, how to edit the realm, limits and non-goals).
- `docs/development/index.md` — added to the TOC.
- `docs/architecture/keycloak-spa-authentication.md` — "Local development" pointer + corrected the `smartem-frontend` → `SmartEM` client-name discrepancy.

## Quick start

```bash
# Compose form (frontend only)
cd keycloak-mock && docker compose up -d

# Or k3s form (along with the rest of the dev stack)
./scripts/k8s/dev-k8s.sh up
```

Then in `smartem-frontend/apps/smartem/.env.local`:

```env
VITE_KEYCLOAK_URL=http://localhost:30090
VITE_KEYCLOAK_REALM=dls
VITE_KEYCLOAK_CLIENT_ID=SmartEM
VITE_AUTH_ENABLED=true
```

Log in as `devuser` / `devpass`.

## Verified end-to-end

The full chain — SPA -> Keycloak -> SPA with token -> backend `/acquisitions` -> backend validates JWT against `keycloak-service:8080` JWKS -> 200 + payload — runs cleanly on a local single-node k3s with all three branches applied (#74, this PR, smartem-decisions `feat/keycloak-jwt-validation`).

## Test plan

- [x] `kubectl kustomize keycloak-mock` builds cleanly
- [x] `kubectl kustomize k8s/environments/development` builds cleanly with Keycloak and KEYCLOAK_* envs included
- [x] `docker compose up -d` in `keycloak-mock/` imports the `dls` realm and exposes the admin console at `http://localhost:8080`
- [x] `./scripts/k8s/dev-k8s.sh up` brings Keycloak up alongside the rest of the stack, reachable at `http://<node-ip>:30090`
- [x] Frontend (DiamondLightSource/smartem-frontend#74 with its silent-SSO and gate fixes) logs in via the mock and the account menu shows the user identity
- [x] Backend pod with `KEYCLOAK_AUTH_REQUIRED=true` fetches JWKS from `http://keycloak-service:8080` and accepts a real `devuser` token
