### PR TITLE
fix(deps): bump idna 3.11 -> 3.15 (CVE-2026-45409)

### DIFF
--- a/packages/smartem-workspace/uv.lock
+++ b/packages/smartem-workspace/uv.lock
@@ -185,11 +185,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `idna` transitive dep in `packages/smartem-workspace/uv.lock` from 3.11 to 3.15.
- Clears [code-scanning alert #20](https://github.com/DiamondLightSource/smartem-devtools/security/code-scanning/20) (GHSA-65pc-fj4g-8rjx / CVE-2026-45409).
- DoS in `idna.encode()` via crafted long inputs that bypass the CVE-2024-3651 length check; 3.15 rejects oversized inputs earlier. Not exploitable here (smartem-workspace does not pass user-controlled domain strings to idna) but bumping clears the alert.

## Test plan
- [x] `uv lock --upgrade-package idna` → 3.11 → 3.15, single-file lockfile diff
- [x] `uv sync --extra dev` clean
- [x] `uv run pytest -q` → 16 passed