### PR TITLE
docs(release): document smartem-frontend pipeline + refresh artefacts dropdown

### DIFF
--- a/core/artefacts.json
+++ b/core/artefacts.json
@@ -27,9 +27,13 @@
     {
       "id": "frontend",
       "label": "SmartEM Frontend",
-      "url": "#",
-      "description": "SmartEM Web UI - deployed via backend container, no standalone bundle published",
-      "command": ""
+      "url": "https://github.com/DiamondLightSource/smartem-frontend/pkgs/container/smartem-frontend",
+      "description": "SmartEM Web UI - nginx-served SPA that talks to the smartem-decisions backend API",
+      "command": "docker pull ghcr.io/diamondlightsource/smartem-frontend:latest",
+      "links": [
+        { "label": "GitHub Releases", "url": "https://github.com/DiamondLightSource/smartem-frontend/releases" },
+        { "label": "Docker", "url": "https://github.com/DiamondLightSource/smartem-frontend/pkgs/container/smartem-frontend" }
+      ]
     },
     {
       "id": "workspace",

--- a/docs/operations/releasing.md
+++ b/docs/operations/releasing.md
@@ -146,6 +146,78 @@ uvx --refresh smartem-workspace --help
 uvx smartem-workspace@latest --help
 ```
 
+## smartem-frontend
+
+**Repository:** [DiamondLightSource/smartem-frontend](https://github.com/DiamondLightSource/smartem-frontend)
+**Workflow:** `release-smartem-frontend.yml`
+**Versioning:** Manual — set in both `apps/smartem/package.json` and `apps/smartem/src/version.ts` (must match)
+**Tag prefix:** `smartem-frontend-v`
+**App directory:** `apps/smartem/`
+
+### Path filters
+
+The workflow triggers on changes to:
+
+- `apps/smartem/**`
+- `packages/api/**`
+- `packages/ui/**`
+- `package.json`, `package-lock.json`
+- `Dockerfile`
+- `scripts/write-version-json.mjs`
+- `.github/workflows/release-smartem-frontend.yml`
+
+`apps/legacy/**` is excluded by design.
+
+### Artifacts produced
+
+- SPA `dist/` (CI artefact, every run)
+- Docker container image (GHCR, stable and RC)
+- GitHub Release with auto-generated notes (stable and RC; RC is marked prerelease)
+
+### Bumping the version
+
+Update both files before tagging:
+
+```jsonc
+// apps/smartem/package.json
+"version": "0.2.0"
+```
+
+```ts
+// apps/smartem/src/version.ts
+export const FRONTEND_VERSION = '0.2.0' as const
+```
+
+The CI `version` job fails if the two values don't match. RCs are skipped if a stable tag already exists for the current
+version — bump the version before merging the next batch of changes to `main` if you want fresh RCs.
+
+### Releasing a stable version
+
+```bash
+git tag smartem-frontend-v0.2.0
+git push origin smartem-frontend-v0.2.0
+```
+
+CI will:
+
+1. Determine the version from the tag and validate it matches `package.json` and `version.ts`
+2. Run `biome check` and `tsc` across the workspace
+3. Generate the API client (`npm run api:generate`), write `version.json`, and run `npm run build:smartem`
+4. Build and push the Docker image to GHCR as `ghcr.io/diamondlightsource/smartem-frontend:{VERSION}` and `:latest`
+5. Create a GitHub Release tagged `smartem-frontend-v{VERSION}`
+
+### Runtime version metadata
+
+The image emits `/version` (aliased to `version.json` by `apps/smartem/nginx.conf`):
+
+```bash
+curl https://<host>/version
+# { "frontend": "0.2.0", "backendApi": "...", "gitSha": "...", "buildTime": "..." }
+```
+
+`frontend` is sourced from the build-time `FRONTEND_VERSION` arg, `backendApi` from the bundled OpenAPI spec, `gitSha`
+and `buildTime` from `git` at build time — see `scripts/write-version-json.mjs`.
+
 ## Manual / emergency releases
 
 All three workflows support `workflow_dispatch`. Go to the Actions tab of the relevant repository, select the release
@@ -176,10 +248,15 @@ pip install smartem-epuplayer==1.2.0
 pip install smartem-workspace==0.7.0
 ```
 
-### Docker (smartem-decisions stable only)
+### Docker
 
 ```bash
+# smartem-decisions (stable only)
 docker pull ghcr.io/diamondlightsource/smartem-decisions:0.2.0
+
+# smartem-frontend (stable and RC)
+docker pull ghcr.io/diamondlightsource/smartem-frontend:0.2.0
+docker pull ghcr.io/diamondlightsource/smartem-frontend:0.2.0rc1
 ```
 
 ### Windows executable


### PR DESCRIPTION
## Summary

Follow-up to the smartem-frontend release pipeline going live (smartem-frontend#90, first stable release `0.1.0` produced earlier today alongside `0.1.0rc5`). This PR propagates references to the new release across smartem-devtools:

- **`docs/operations/releasing.md`**: add a fourth section for `smartem-frontend`, mirroring the existing three (decisions / epuplayer / workspace). Covers path filters, artifacts produced, the dual-file versioning rule (`apps/smartem/package.json` and `apps/smartem/src/version.ts` must match), the stable-release tag flow, and a short note on the `/version` runtime metadata endpoint. Expand the \"Docker\" subsection under \"Verifying a release\" to cover the new image alongside `smartem-decisions`.
- **`core/artefacts.json`**: replace the placeholder `frontend` entry (\"deployed via backend container, no standalone bundle published\") with a real one mirroring the `backend` shape — label, description, `docker pull` command, and links to GitHub Releases and the GHCR package.

## What this PR does NOT do

- No k8s manifest changes — coming in a separate PR. There's also an API-endpoint resolution gap to think through first: the published image bakes `VITE_API_ENDPOINT` at build time but the release workflow doesn't set it, so the bundle's `apiUrl()` falls back to `http://localhost:8000` at runtime. Worth deciding (relative `/api` + nginx reverse proxy in the SPA image, or per-environment build args, or runtime config injection) before writing k8s manifests that point at a backend the bundle can't reach.
- No follow-up to wire `packages/api/src/version-check.ts` into `main.tsx` — tracked separately in smartem-frontend#93.

## Verification

- `npm run typecheck` in `webui/` passes after the JSON edit (the entry conforms to the existing `ArtefactItem` type — same shape as `backend`).
- `python3 -c \"json.load(open('core/artefacts.json'))\"` parses cleanly.
- The releasing-docs page is auto-published to GitHub Pages — landing this PR will refresh that.

## Test plan

- [ ] CI lint/build passes on the PR
- [ ] After merge, the GH Pages site renders the new \"smartem-frontend\" section in `docs/operations/releasing.md`
- [ ] The deployed webui's \"Artefacts\" dropdown shows the SmartEM Frontend entry with the new docker pull command and links