### PR TITLE
fix(webui): broken favicon + add Security tab link in repo dropdown

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/webui/public/favicon.svg
+++ b/webui/public/favicon.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="10" fill="#1a1a1a"/>
+
+  <!-- ears (big, pointy, bat-like) -->
+  <path d="M6 18 L18 28 L14 36 Z" fill="#3a8a3a"/>
+  <path d="M58 18 L46 28 L50 36 Z" fill="#3a8a3a"/>
+  <path d="M9 20 L17 27 L15 32 Z" fill="#1f5a1f"/>
+  <path d="M55 20 L47 27 L49 32 Z" fill="#1f5a1f"/>
+
+  <!-- head -->
+  <path d="M14 28 Q14 14 32 14 Q50 14 50 28 L50 42 Q50 56 32 56 Q14 56 14 42 Z" fill="#4ea84e"/>
+
+  <!-- cheek shading -->
+  <path d="M14 36 Q18 50 32 56 Q46 50 50 36 L50 42 Q50 56 32 56 Q14 56 14 42 Z" fill="#3a8a3a"/>
+
+  <!-- small horns / tufts on top -->
+  <path d="M22 14 L24 8 L27 14 Z" fill="#3a8a3a"/>
+  <path d="M37 14 L40 8 L42 14 Z" fill="#3a8a3a"/>
+
+  <!-- silly asymmetric brows: one high arch (surprised) + one low (puzzled) -->
+  <path d="M16 22 Q23 17 30 22" stroke="#0a0a0a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M34 27 Q40 25 48 27" stroke="#0a0a0a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+
+  <!-- googly eyes: big white sclera, pupils looking in different directions -->
+  <circle cx="24" cy="32" r="6" fill="#ffffff"/>
+  <circle cx="40" cy="32" r="6" fill="#ffffff"/>
+  <!-- pupils: cross-eyed / wandering for max silly -->
+  <circle cx="27" cy="33" r="2.4" fill="#0a0a0a"/>
+  <circle cx="37" cy="31" r="2.4" fill="#0a0a0a"/>
+  <!-- pupil highlights -->
+  <circle cx="26.4" cy="32.3" r="0.8" fill="#ffffff"/>
+  <circle cx="36.4" cy="30.3" r="0.8" fill="#ffffff"/>
+
+  <!-- nose (small snout) -->
+  <path d="M30 39 Q32 41 34 39 Q34 42 32 43 Q30 42 30 39 Z" fill="#1f5a1f"/>
+
+  <!-- goofy lopsided open mouth -->
+  <path d="M22 45 Q32 53 43 46 Q41 50 32 51 Q24 51 22 45 Z" fill="#0a0a0a"/>
+  <!-- tongue sticking out the side -->
+  <path d="M34 50 Q38 52 41 55 Q42 57 39 57 Q35 56 33 53 Z" fill="#ff7aa8"/>
+  <!-- single goofy fang -->
+  <path d="M27 45 L28.5 49 L30 45 Z" fill="#ffffff"/>
+</svg>

--- a/webui/src/components/header/RepoStatsDisplay.tsx
+++ b/webui/src/components/header/RepoStatsDisplay.tsx
@@ -13,6 +13,13 @@ interface RepoStatsDisplayProps {
   isGitHub: boolean
 }
 
+const SECURITY_TRACKED_REPOS = new Set([
+  'DiamondLightSource/smartem-decisions',
+  'DiamondLightSource/smartem-frontend',
+  'DiamondLightSource/smartem-devtools',
+  'DiamondLightSource/fandanGO-cryoem-dls',
+])
+
 function formatRelativeTime(dateString: string): string {
   if (!dateString) return ''
 
@@ -59,6 +66,7 @@ export function RepoStatsDisplay({ owner, repo, isGitHub }: RepoStatsDisplayProp
   }
 
   const repoUrl = `https://github.com/${owner}/${repo}`
+  const showSecurityLink = isGitHub && SECURITY_TRACKED_REPOS.has(`${owner}/${repo}`)
 
   if (!isGitHub || !statsEnabled) {
     return (
@@ -131,6 +139,24 @@ export function RepoStatsDisplay({ owner, repo, isGitHub }: RepoStatsDisplayProp
         </Box>
       </Box>
       <span>|</span>
+      {showSecurityLink && (
+        <>
+          <Box
+            component="a"
+            href={`${repoUrl}/security`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            title="Open the Security tab on GitHub"
+            sx={linkStyle}
+          >
+            <Box component="span" sx={numberStyle}>
+              Security
+            </Box>
+          </Box>
+          <span>|</span>
+        </>
+      )}
       <Box
         component="a"
         href={`${repoUrl}/commit/${data.lastCommitFullSha}`}


### PR DESCRIPTION
## Summary

Two small unrelated webui fixes for the GitHub Pages dashboard.

### 1. Favicon

`index.html` still pointed at the default Vite template's `/vite.svg`, but that file was never added to `webui/public/`, so the deployed Pages tab showed a blank/default browser icon. Replaced with a custom gremlin SVG (`webui/public/favicon.svg`) and fixed the `href`.

### 2. Security tab link

Added a "Security" link to the repo stats row in the codebases dropdown for the four owned GitHub repos:

- DiamondLightSource/smartem-decisions
- DiamondLightSource/smartem-frontend
- DiamondLightSource/smartem-devtools
- DiamondLightSource/fandanGO-cryoem-dls

The link points to `${repoUrl}/security` (not `/security/dependabot`) so it covers dependabot, code-scanning, and secret-scanning. No count is shown because the GitHub security endpoints require authentication and the deployed dashboard is a public static site with no token storage.

## Test plan

- [x] Favicon renders correctly at 16/32/64/128/256 px in a local preview
- [x] `npm run typecheck` passes
- [x] `npx biome check` passes
- [x] Pre-commit hooks (biome, prettier, gitleaks, lint, typecheck) pass on push
- [ ] CI green on PR
- [ ] After deploy, verify favicon shows on https://diamondlightsource.github.io/smartem-devtools/
- [ ] After deploy, verify Security link appears for the 4 owned repos in the dropdown