### PR TITLE
chore(k8s): wire prod Keycloak config and real CORS origin

### DIFF
--- a/k8s/environments/production/configmap.yaml
+++ b/k8s/environments/production/configmap.yaml
@@ -13,4 +13,13 @@ data:
   RABBITMQ_PORT: "5672"
   HTTP_API_PORT: "8000"
   ADMINER_PORT: "8080"
-  CORS_ALLOWED_ORIGINS: "https://app.example.com"
+  CORS_ALLOWED_ORIGINS: "https://smartem.diamond.ac.uk"
+  # Keycloak OIDC integration. The backend rejects every non-exempt
+  # request that doesn't carry a valid Bearer token (always-on since
+  # smartem-decisions#285). KEYCLOAK_ALLOWED_AZP is the comma-separated
+  # azp allow-list; unset means any valid token from the realm is accepted.
+  KEYCLOAK_URL: "https://identity.diamond.ac.uk"
+  KEYCLOAK_ALLOWED_AZP: "SmartEM_User,SmartEM_Agent"
+  # TODO: confirm with DLS Keycloak admins before go-live
+  #   KEYCLOAK_REALM
+  #   KEYCLOAK_VERIFY_ISS  (set "true" once realm is known so the issuer URL can be validated)


### PR DESCRIPTION
## Summary

Two prod-deploy blockers fixed in `k8s/environments/production/configmap.yaml`:

1. `CORS_ALLOWED_ORIGINS` was the `https://app.example.com` placeholder. Set to the real prod ingress hostname `https://smartem.diamond.ac.uk` (matches `production/ingress.yaml`).
2. No Keycloak config at all in prod. Backend is always-on auth (`smartem-decisions#285`) so without this the prod backend will 403 every non-exempt request. Added:
   - `KEYCLOAK_URL: https://identity.diamond.ac.uk`
   - `KEYCLOAK_ALLOWED_AZP: SmartEM_User,SmartEM_Agent`

`KEYCLOAK_REALM` and `KEYCLOAK_VERIFY_ISS` left as TODO comments pending confirmation from DLS Keycloak admins (per "verify or omit" rule for DLS-facing config).

## Test plan

- [ ] DLS Keycloak admins confirm realm name; backfill `KEYCLOAK_REALM` and `KEYCLOAK_VERIFY_ISS: "true"` before go-live
- [ ] Once SmartEM_User + SmartEM_Agent clients exist in prod realm, smoke-test backend with a token from each