### PR TITLE
chore(k8s): set prod KEYCLOAK_REALM=dls and enable issuer verification

### DIFF
--- a/k8s/environments/production/configmap.yaml
+++ b/k8s/environments/production/configmap.yaml
@@ -23,7 +23,6 @@ data:
   # smartem-decisions#285). KEYCLOAK_ALLOWED_AZP is the comma-separated
   # azp allow-list; unset means any valid token from the realm is accepted.
   KEYCLOAK_URL: "https://identity.diamond.ac.uk"
+  KEYCLOAK_REALM: "dls"
+  KEYCLOAK_VERIFY_ISS: "true"
   KEYCLOAK_ALLOWED_AZP: "SmartEM_User,SmartEM_Agent"
-  # TODO: confirm with DLS Keycloak admins before go-live
-  #   KEYCLOAK_REALM
-  #   KEYCLOAK_VERIFY_ISS  (set "true" once realm is known so the issuer URL can be validated)


### PR DESCRIPTION
## Summary

Fills in the TODO values left in `k8s/environments/production/configmap.yaml` by PR #209:

- `KEYCLOAK_REALM: "dls"`
- `KEYCLOAK_VERIFY_ISS: "true"`

DLS Keycloak admins confirmed realm name `dls` on the test instance (`identity-test.diamond.ac.uk/realms/dls`). DLS typically maintains one realm naming convention across test and prod, so prod is expected to use the same. If wrong, this is a one-line revert.

## Test plan

- [ ] CI green
- [ ] Once prod Keycloak clients exist (SmartEM_User + SmartEM_Agent on prod realm) and the prod backend is deployed, confirm with a real token that issuer validation passes