### PR TITLE
fix(dev-k8s): resolve Dockerfile.dev from smartem-decisions, refresh devops skill

### DIFF
--- a/claude-code/shared/skills/devops/SKILL.md
+++ b/claude-code/shared/skills/devops/SKILL.md
@@ -39,10 +39,12 @@ If you encounter this error, advise the user to run the above command. Other per
 
 **Cluster management:**
 
-```bash
-cd repos/DiamondLightSource/smartem-decisions
+The `dev-k8s.sh` orchestration script lives in **smartem-devtools** (it used to live in smartem-decisions). It needs a sibling checkout of `smartem-decisions` to build the backend image from `Dockerfile.dev`; override `SMARTEM_DECISIONS_PATH` if your layout differs.
 
-# Start local k3s cluster with all services
+```bash
+cd repos/DiamondLightSource/smartem-devtools
+
+# Start local k3s cluster with all services (backend, postgres, rabbitmq, mongo, es, keycloak mock, FE)
 ./scripts/k8s/dev-k8s.sh up
 
 # Stop and cleanup
@@ -52,6 +54,12 @@ cd repos/DiamondLightSource/smartem-decisions
 kubectl get pods -n smartem-decisions
 kubectl get services -n smartem-decisions
 ```
+
+**Keycloak in the dev stack:**
+
+The in-cluster Keycloak mock (`keycloak-mock/keycloak.yaml`, pulled in via the development kustomization) is the primary local auth provider. It is brought up automatically by `dev-k8s.sh up` and reachable at `http://localhost:30090`.
+
+The `keycloak-mock/docker-compose.yml` in the same directory is a **fallback for FE-only development** — use it when working inside `smartem-frontend` in isolation without the rest of the k3s stack. Do not run both at once or the NodePort/host-port mapping will collide.
 
 ### Services (smartem-decisions namespace)
 
@@ -77,7 +85,10 @@ k8s/
 ```bash
 cd repos/DiamondLightSource/smartem-decisions
 
-# Build backend image
+# Build local dev backend image (matches what dev-k8s.sh expects)
+docker build -f Dockerfile.dev -t smartem-decisions:latest .
+
+# Build production image
 docker build -t smartem-backend:dev .
 
 # Build with specific Python version (from Dockerfile)
@@ -86,6 +97,8 @@ docker build --build-arg PYTHON_VERSION=3.12 -t smartem-backend:dev .
 # Multi-stage build (production)
 docker build --target production -t smartem-backend:prod .
 ```
+
+`dev-k8s.sh up` will build `smartem-decisions:latest` automatically if it is missing, loading it into k3s containerd. Pre-build it manually only if you want to iterate without re-running `up`.
 
 ### Push to Registry
 

--- a/docs/operations/kubernetes.md
+++ b/docs/operations/kubernetes.md
@@ -35,6 +35,15 @@ Once the environment is running, you can access:
 
 > **Note**: The script automatically handles GitHub Container Registry authentication and waits for all pods to be ready.
 
+### Pointing the SmartEM frontend dev server at this stack
+
+The Vite dev server in `smartem-frontend` proxies `/api` to `http://localhost:8000` by default — the conventional port for a standalone backend (`uvicorn` directly, or a `kubectl port-forward`). When the backend is in the dev k3s stack, two options:
+
+- **No port-forward** (simplest) — set `VITE_API_PROXY_TARGET=http://localhost:30080` in `apps/smartem/.env.local`. Vite proxies straight to the NodePort.
+- **Port-forward to 8000** — `kubectl port-forward -n smartem-decisions svc/smartem-http-api-service 8000:80` keeps the default proxy target working. Useful if you also want CLI tools that hit `http://localhost:8000` to keep working unchanged.
+
+Keycloak is reachable on `http://localhost:30090` regardless; see [Local Keycloak](../development/local-keycloak.md) for the SPA's runtime auth config.
+
 ## Kubernetes Structure
 
 ```

--- a/scripts/k8s/dev-k8s.sh
+++ b/scripts/k8s/dev-k8s.sh
@@ -6,6 +6,9 @@ NAMESPACE="smartem-decisions"
 K8S_ENV_PATH="k8s/environments/development"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# smartem-decisions repo holds Dockerfile.dev for the local backend image build.
+# Override SMARTEM_DECISIONS_PATH if your checkout layout is not the conventional sibling.
+SMARTEM_DECISIONS_PATH="${SMARTEM_DECISIONS_PATH:-$PROJECT_ROOT/../smartem-decisions}"
 DEPLOY_ENV="${DEPLOY_ENV:-development}"
 
 # Colors for output
@@ -380,9 +383,16 @@ ensure_local_image() {
 
     # Check if image exists in Docker
     if ! docker image inspect "$image_name" &> /dev/null; then
-        log_info "Building SmartEM image..."
-        cd "$PROJECT_ROOT"
+        if [[ ! -f "$SMARTEM_DECISIONS_PATH/Dockerfile.dev" ]]; then
+            log_error "Dockerfile.dev not found at: $SMARTEM_DECISIONS_PATH/Dockerfile.dev"
+            log_error "Set SMARTEM_DECISIONS_PATH to the smartem-decisions repo checkout, or"
+            log_error "clone it as a sibling of smartem-devtools."
+            exit 1
+        fi
+        log_info "Building SmartEM image from $SMARTEM_DECISIONS_PATH..."
+        cd "$SMARTEM_DECISIONS_PATH"
         docker build -f Dockerfile.dev -t "$image_name" .
+        cd "$PROJECT_ROOT"
     else
         log_info "SmartEM image already exists in Docker"
     fi

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
           {
             theme: 'github-dark',
             keepBackground: true,
+            defaultLang: 'text',
           },
         ],
       ],


### PR DESCRIPTION
## Summary

- `dev-k8s.sh ensure_local_image` ran `docker build -f Dockerfile.dev` from `smartem-devtools`, but the file lives in `smartem-decisions`. The build failed on every fresh `up` and the workaround (pre-build manually) was undocumented.
- Adds `SMARTEM_DECISIONS_PATH` (defaults to the conventional sibling checkout) so the script knows where to find `Dockerfile.dev`, and fails fast with an actionable message if the file is missing.
- Brings the devops skill back in sync with reality: script path moved to `smartem-devtools`, in-cluster Keycloak is the primary local auth provider, docker-compose Keycloak is the FE-only fallback, and the container build command matches the image tag `dev-k8s.sh` expects.

## Why

Triggered while bringing up the local dev stack to test the FE against a fresh DB dump. `dev-k8s.sh up` failed with:

```
ERROR: failed to solve: failed to read dockerfile: open Dockerfile.dev: no such file or directory
```

Worked around by building manually first, but the on-disk skill instructions still pointed at the old `smartem-decisions/scripts/k8s/dev-k8s.sh` path and made no mention of the in-cluster Keycloak.

## Test plan

- [x] `bash -n scripts/k8s/dev-k8s.sh` passes
- [x] `SMARTEM_DECISIONS_PATH` resolves to the conventional sibling layout under `repos/DiamondLightSource/`
- [x] `dev-k8s.sh up` reaches "All pods are running" with a freshly built backend image
- [ ] Verify on a layout where smartem-decisions is at a non-default path by setting `SMARTEM_DECISIONS_PATH` explicitly