### PR TITLE
chore: refresh SmartEM OpenAPI spec from current backend

### DIFF
--- a/docs/api/smartem/swagger.json
+++ b/docs/api/smartem/swagger.json
@@ -1,85 +1,3576 @@
 {
+  "openapi": "3.1.0",
+  "info": {
+    "title": "SmartEM Decisions Backend API",
+    "description": "API for accessing and managing electron microscopy data",
+    "version": "0.1.1rc48.dev3+gcd5206327"
+  },
+  "paths": {
+    "/status": {
+      "get": {
+        "summary": "Get Status",
+        "description": "Get API status and configuration information",
+        "operationId": "get_status_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Get Health",
+        "description": "Health check endpoint with actual connectivity checks",
+        "operationId": "get_health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/acquisitions": {
+      "get": {
+        "summary": "Get Acquisitions",
+        "description": "Get all acquisitions",
+        "operationId": "get_acquisitions_acquisitions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AcquisitionResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Acquisitions Acquisitions Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Acquisition",
+        "description": "Create a new acquisition",
+        "operationId": "create_acquisition_acquisitions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcquisitionCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/acquisitions/grid-counts": {
+      "get": {
+        "summary": "Get Acquisition Grid Counts",
+        "description": "Per-acquisition grid totals for summary views.\n\nA single grouped query in place of one /acquisitions/{uuid}/grids call per\nacquisition. Every acquisition is returned, including those with no grids\n(grids_total == 0), via an outer join. Declared before the\n/acquisitions/{acquisition_uuid} route so the static segment is matched\nfirst rather than being parsed as a uuid.",
+        "operationId": "get_acquisition_grid_counts_acquisitions_grid_counts_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AcquisitionGridCountResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Acquisition Grid Counts Acquisitions Grid Counts Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/acquisitions/{acquisition_uuid}": {
+      "get": {
+        "summary": "Get Acquisition",
+        "description": "Get a single acquisition by ID",
+        "operationId": "get_acquisition_acquisitions__acquisition_uuid__get",
+        "parameters": [
+          {
+            "name": "acquisition_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Acquisition Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update Acquisition",
+        "description": "Update an acquisition",
+        "operationId": "update_acquisition_acquisitions__acquisition_uuid__put",
+        "parameters": [
+          {
+            "name": "acquisition_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Acquisition Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcquisitionUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Acquisition",
+        "description": "Delete an acquisition",
+        "operationId": "delete_acquisition_acquisitions__acquisition_uuid__delete",
+        "parameters": [
+          {
+            "name": "acquisition_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Acquisition Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grids": {
+      "get": {
+        "summary": "Get Grids",
+        "description": "Get all grids",
+        "operationId": "get_grids_grids_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Grids Grids Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grids/{grid_uuid}": {
+      "get": {
+        "summary": "Get Grid",
+        "description": "Get a single grid by ID",
+        "operationId": "get_grid_grids__grid_uuid__get",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update Grid",
+        "description": "Update a grid",
+        "operationId": "update_grid_grids__grid_uuid__put",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Grid",
+        "description": "Delete a grid by publishing to RabbitMQ",
+        "operationId": "delete_grid_grids__grid_uuid__delete",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/acquisitions/{acquisition_uuid}/grids": {
+      "get": {
+        "summary": "Get Acquisition Grids",
+        "description": "Get all grids for a specific acquisition",
+        "operationId": "get_acquisition_grids_acquisitions__acquisition_uuid__grids_get",
+        "parameters": [
+          {
+            "name": "acquisition_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Acquisition Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GridResponse"
+                  },
+                  "title": "Response Get Acquisition Grids Acquisitions  Acquisition Uuid  Grids Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Acquisition Grid",
+        "description": "Create a new grid for a specific acquisition",
+        "operationId": "create_acquisition_grid_acquisitions__acquisition_uuid__grids_post",
+        "parameters": [
+          {
+            "name": "acquisition_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Acquisition Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grids/{grid_uuid}/registered": {
+      "post": {
+        "summary": "Grid Registered",
+        "description": "All squares on a grid have been registered at low mag",
+        "operationId": "grid_registered_grids__grid_uuid__registered_post",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "title": "Response Grid Registered Grids  Grid Uuid  Registered Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlases": {
+      "get": {
+        "summary": "Get Atlases",
+        "description": "Get all atlases",
+        "operationId": "get_atlases_atlases_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Atlases Atlases Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlases/{atlas_uuid}": {
+      "get": {
+        "summary": "Get Atlas",
+        "description": "Get a single atlas by ID",
+        "operationId": "get_atlas_atlases__atlas_uuid__get",
+        "parameters": [
+          {
+            "name": "atlas_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Atlas Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update Atlas",
+        "description": "Update an atlas",
+        "operationId": "update_atlas_atlases__atlas_uuid__put",
+        "parameters": [
+          {
+            "name": "atlas_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Atlas Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Atlas",
+        "description": "Delete an atlas by publishing to RabbitMQ",
+        "operationId": "delete_atlas_atlases__atlas_uuid__delete",
+        "parameters": [
+          {
+            "name": "atlas_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Atlas Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grids/{grid_uuid}/atlas": {
+      "get": {
+        "summary": "Get Grid Atlas",
+        "description": "Get the atlas for a specific grid",
+        "operationId": "get_grid_atlas_grids__grid_uuid__atlas_get",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Grid Atlas",
+        "description": "Create a new atlas for a grid",
+        "operationId": "create_grid_atlas_grids__grid_uuid__atlas_post",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlas-tiles": {
+      "get": {
+        "summary": "Get Atlas Tiles",
+        "description": "Get all atlas tiles",
+        "operationId": "get_atlas_tiles_atlas_tiles_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Atlas Tiles Atlas Tiles Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlas-tiles/{tile_uuid}": {
+      "get": {
+        "summary": "Get Atlas Tile",
+        "description": "Get a single atlas tile by ID",
+        "operationId": "get_atlas_tile_atlas_tiles__tile_uuid__get",
+        "parameters": [
+          {
+            "name": "tile_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tile Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update Atlas Tile",
+        "description": "Update an atlas tile",
+        "operationId": "update_atlas_tile_atlas_tiles__tile_uuid__put",
+        "parameters": [
+          {
+            "name": "tile_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tile Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasTileUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Atlas Tile",
+        "description": "Delete an atlas tile by publishing to RabbitMQ",
+        "operationId": "delete_atlas_tile_atlas_tiles__tile_uuid__delete",
+        "parameters": [
+          {
+            "name": "tile_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tile Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlases/{atlas_uuid}/tiles": {
+      "get": {
+        "summary": "Get Atlas Tiles By Atlas",
+        "description": "Get all tiles for a specific atlas",
+        "operationId": "get_atlas_tiles_by_atlas_atlases__atlas_uuid__tiles_get",
+        "parameters": [
+          {
+            "name": "atlas_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Atlas Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileResponse"
+                  },
+                  "title": "Response Get Atlas Tiles By Atlas Atlases  Atlas Uuid  Tiles Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Atlas Tile For Atlas",
+        "description": "Create a new tile for a specific atlas",
+        "operationId": "create_atlas_tile_for_atlas_atlases__atlas_uuid__tiles_post",
+        "parameters": [
+          {
+            "name": "atlas_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Atlas Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasTileCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlas-tiles/{tile_uuid}/gridsquares/{gridsquare_uuid}": {
+      "post": {
+        "summary": "Link Atlas Tile To Gridsquare",
+        "description": "Connect a grid square to a tile with its position information",
+        "operationId": "link_atlas_tile_to_gridsquare_atlas_tiles__tile_uuid__gridsquares__gridsquare_uuid__post",
+        "parameters": [
+          {
+            "name": "tile_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tile Uuid"
+            }
+          },
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquarePositionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlas-tiles/{tile_uuid}/gridsquares": {
+      "post": {
+        "summary": "Link Atlas Tile To Gridsquares",
+        "description": "Connect mutliple grid squares to a tile with its position information",
+        "operationId": "link_atlas_tile_to_gridsquares_atlas_tiles__tile_uuid__gridsquares_post",
+        "parameters": [
+          {
+            "name": "tile_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tile Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GridSquarePositionRequest"
+                },
+                "title": "Gridsquare Positions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
+                  },
+                  "title": "Response Link Atlas Tile To Gridsquares Atlas Tiles  Tile Uuid  Gridsquares Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares": {
+      "get": {
+        "summary": "Get Gridsquares",
+        "description": "Get all grid squares",
+        "operationId": "get_gridsquares_gridsquares_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquareResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Gridsquares Gridsquares Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}": {
+      "get": {
+        "summary": "Get Gridsquare",
+        "description": "Get a single grid square by ID",
+        "operationId": "get_gridsquare_gridsquares__gridsquare_uuid__get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update Gridsquare",
+        "description": "Update a grid square",
+        "operationId": "update_gridsquare_gridsquares__gridsquare_uuid__put",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Gridsquare",
+        "description": "Delete a grid square by publishing to RabbitMQ",
+        "operationId": "delete_gridsquare_gridsquares__gridsquare_uuid__delete",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grids/{grid_uuid}/gridsquares": {
+      "get": {
+        "summary": "Get Grid Gridsquares",
+        "description": "Get all grid squares for a specific grid",
+        "operationId": "get_grid_gridsquares_grids__grid_uuid__gridsquares_get",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquareResponse"
+                  },
+                  "title": "Response Get Grid Gridsquares Grids  Grid Uuid  Gridsquares Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Grid Gridsquare",
+        "description": "Create a new grid square for a specific grid",
+        "operationId": "create_grid_gridsquare_grids__grid_uuid__gridsquares_post",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grids/{grid_uuid}/gridsquares/batch": {
+      "post": {
+        "summary": "Create Grid Gridsquares Batch",
+        "description": "Create many grid squares for a grid in a single transaction and a single\nbatched RabbitMQ publish. Solves the overload scenario from issue #249.",
+        "operationId": "create_grid_gridsquares_batch_grids__grid_uuid__gridsquares_batch_post",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareBatchCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareBatchCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/registered": {
+      "post": {
+        "summary": "Gridsquare Registered",
+        "description": "All holes on a grid square have been registered at square mag",
+        "operationId": "gridsquare_registered_gridsquares__gridsquare_uuid__registered_post",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Count"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "title": "Response Gridsquare Registered Gridsquares  Gridsquare Uuid  Registered Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/foilholes": {
+      "get": {
+        "summary": "Get Foilholes",
+        "description": "Get all foil holes",
+        "operationId": "get_foilholes_foilholes_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Foilholes Foilholes Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/foilholes/{foilhole_uuid}": {
+      "get": {
+        "summary": "Get Foilhole",
+        "description": "Get a single foil hole by ID",
+        "operationId": "get_foilhole_foilholes__foilhole_uuid__get",
+        "parameters": [
+          {
+            "name": "foilhole_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Foilhole Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoilHoleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update Foilhole",
+        "description": "Update a foil hole",
+        "operationId": "update_foilhole_foilholes__foilhole_uuid__put",
+        "parameters": [
+          {
+            "name": "foilhole_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Foilhole Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoilHoleUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoilHoleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Foilhole",
+        "description": "Delete a foil hole by publishing to RabbitMQ",
+        "operationId": "delete_foilhole_foilholes__foilhole_uuid__delete",
+        "parameters": [
+          {
+            "name": "foilhole_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Foilhole Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/foilholes": {
+      "get": {
+        "summary": "Get Gridsquare Foilholes",
+        "description": "Get all foil holes for a specific grid square",
+        "operationId": "get_gridsquare_foilholes_gridsquares__gridsquare_uuid__foilholes_get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          },
+          {
+            "name": "on_square_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "On Square Only"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "title": "Response Get Gridsquare Foilholes Gridsquares  Gridsquare Uuid  Foilholes Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Gridsquare Foilhole",
+        "description": "Create a new foil hole for a specific grid square",
+        "operationId": "create_gridsquare_foilhole_gridsquares__gridsquare_uuid__foilholes_post",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FoilHoleCreateRequest"
+                },
+                "title": "Foilholes"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "title": "Response Create Gridsquare Foilhole Gridsquares  Gridsquare Uuid  Foilholes Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/micrographs": {
+      "get": {
+        "summary": "Get Micrographs",
+        "description": "Get all micrographs",
+        "operationId": "get_micrographs_micrographs_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MicrographResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Micrographs Micrographs Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/micrographs/{micrograph_uuid}": {
+      "get": {
+        "summary": "Get Micrograph",
+        "description": "Get a single micrograph by ID",
+        "operationId": "get_micrograph_micrographs__micrograph_uuid__get",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MicrographResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update Micrograph",
+        "description": "Update a micrograph",
+        "operationId": "update_micrograph_micrographs__micrograph_uuid__put",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MicrographUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MicrographResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Micrograph",
+        "description": "Delete a micrograph by publishing to RabbitMQ",
+        "operationId": "delete_micrograph_micrographs__micrograph_uuid__delete",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/micrographs/{micrograph_uuid}/motion_correction/completed": {
+      "post": {
+        "summary": "Publish Micrograph Motion Correction Completed",
+        "description": "Publish a motion-correction-completed event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_motion_correction_completed_micrographs__micrograph_uuid__motion_correction_completed_post",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MotionCorrectionCompletedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/micrographs/{micrograph_uuid}/motion_correction/registered": {
+      "post": {
+        "summary": "Publish Micrograph Motion Correction Registered",
+        "description": "Publish a motion-correction-registered event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_motion_correction_registered_micrographs__micrograph_uuid__motion_correction_registered_post",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MotionCorrectionRegisteredRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/micrographs/{micrograph_uuid}/ctf_estimation/completed": {
+      "post": {
+        "summary": "Publish Micrograph Ctf Estimation Completed",
+        "description": "Publish a CTF-estimation-completed event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_ctf_estimation_completed_micrographs__micrograph_uuid__ctf_estimation_completed_post",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CtfEstimationCompletedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/micrographs/{micrograph_uuid}/ctf_estimation/registered": {
+      "post": {
+        "summary": "Publish Micrograph Ctf Estimation Registered",
+        "description": "Publish a CTF-estimation-registered event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_ctf_estimation_registered_micrographs__micrograph_uuid__ctf_estimation_registered_post",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CtfEstimationRegisteredRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/foilholes/{foilhole_uuid}/micrographs": {
+      "get": {
+        "summary": "Get Foilhole Micrographs",
+        "description": "Get all micrographs for a specific foil hole",
+        "operationId": "get_foilhole_micrographs_foilholes__foilhole_uuid__micrographs_get",
+        "parameters": [
+          {
+            "name": "foilhole_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Foilhole Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MicrographResponse"
+                  },
+                  "title": "Response Get Foilhole Micrographs Foilholes  Foilhole Uuid  Micrographs Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Foilhole Micrograph",
+        "description": "Create a new micrograph for a specific foil hole",
+        "operationId": "create_foilhole_micrograph_foilholes__foilhole_uuid__micrographs_post",
+        "parameters": [
+          {
+            "name": "foilhole_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Foilhole Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MicrographCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MicrographResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_models": {
+      "get": {
+        "summary": "Get Prediction Models",
+        "operationId": "get_prediction_models_prediction_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Prediction Models Prediction Models Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Prediction Model",
+        "operationId": "create_prediction_model_prediction_models_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionModelCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_models/{name}": {
+      "get": {
+        "summary": "Get Prediction Model",
+        "operationId": "get_prediction_model_prediction_models__name__get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update Prediction Model",
+        "operationId": "update_prediction_model_prediction_models__name__put",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionModelUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Prediction Model",
+        "operationId": "delete_prediction_model_prediction_models__name__delete",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/quality_predictions": {
+      "get": {
+        "summary": "Get Gridsquare Quality Prediction Time Series",
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_gridsquare_quality_prediction_time_series_gridsquares__gridsquare_uuid__quality_predictions_get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/QualityPrediction"
+                    }
+                  },
+                  "title": "Response Get Gridsquare Quality Prediction Time Series Gridsquares  Gridsquare Uuid  Quality Predictions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
+      "get": {
+        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare",
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/QualityPrediction"
+                      }
+                    }
+                  },
+                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quality_predictions": {
+      "post": {
+        "summary": "Create Quality Prediction",
+        "operationId": "create_quality_prediction_quality_predictions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quality_metrics": {
+      "get": {
+        "summary": "Get Quality Metrics",
+        "operationId": "get_quality_metrics_quality_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityMetricsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/prediction": {
+      "get": {
+        "summary": "Get Prediction For Grid",
+        "operationId": "get_prediction_for_grid_prediction_model__prediction_model_name__grid__grid_uuid__prediction_get",
+        "parameters": [
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionResponse"
+                  },
+                  "title": "Response Get Prediction For Grid Prediction Model  Prediction Model Name  Grid  Grid Uuid  Prediction Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/latent_representation": {
+      "get": {
+        "summary": "Get Latent Rep",
+        "operationId": "get_latent_rep_prediction_model__prediction_model_name__grid__grid_uuid__latent_representation_get",
+        "parameters": [
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LatentRepresentationResponse"
+                  },
+                  "title": "Response Get Latent Rep Prediction Model  Prediction Model Name  Grid  Grid Uuid  Latent Representation Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/instructions/stream": {
+      "get": {
+        "summary": "Stream Instructions",
+        "description": "SSE endpoint for streaming instructions to agents for a specific session.\n\nUses PostgreSQL LISTEN/NOTIFY (channel `agent_instructions`, payload = session_id)\ninstead of polling: a dedicated asyncpg connection holds a LISTEN, the main loop\nawaits the next notification or a heartbeat timeout, and only queries the\ndatabase when a notification arrives or on initial connect.",
+        "operationId": "stream_instructions_agent__agent_id__session__session_id__instructions_stream_get",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/instructions/{instruction_id}/ack": {
+      "post": {
+        "summary": "Acknowledge Instruction",
+        "description": "HTTP endpoint for instruction acknowledgements with database persistence",
+        "operationId": "acknowledge_instruction_agent__agent_id__session__session_id__instructions__instruction_id__ack_post",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "instruction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Instruction Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstructionAcknowledgement"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstructionAcknowledgementResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/heartbeat": {
+      "post": {
+        "summary": "Agent Heartbeat",
+        "description": "Agent heartbeat endpoint to update connection health status.\n\nArgs:\n    agent_id: The agent identifier\n    session_id: The session identifier\n    db: Database session\n\nReturns:\n    Heartbeat response with status and timestamp",
+        "operationId": "agent_heartbeat_agent__agent_id__session__session_id__heartbeat_post",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/agent-connections": {
+      "get": {
+        "summary": "Get Active Connections",
+        "description": "Debug endpoint to view active agent connections",
+        "operationId": "get_active_connections_debug_agent_connections_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/session/{session_id}/instructions": {
+      "get": {
+        "summary": "Get Session Instructions",
+        "description": "Debug endpoint to view instructions for a session",
+        "operationId": "get_session_instructions_debug_session__session_id__instructions_get",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/sessions": {
+      "get": {
+        "summary": "Get Active Sessions",
+        "description": "Debug endpoint to view all active sessions",
+        "operationId": "get_active_sessions_debug_sessions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/connection-stats": {
+      "get": {
+        "summary": "Get Connection Stats",
+        "description": "Get real-time connection and session statistics",
+        "operationId": "get_connection_stats_debug_connection_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/sessions/create-managed": {
+      "post": {
+        "summary": "Create Managed Session",
+        "description": "Create a session using the connection manager",
+        "operationId": "create_managed_session_debug_sessions_create_managed_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Session Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/sessions/{session_id}/close": {
+      "delete": {
+        "summary": "Close Managed Session",
+        "description": "Close a session using the connection manager",
+        "operationId": "close_managed_session_debug_sessions__session_id__close_delete",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/session/{session_id}/create-instruction": {
+      "post": {
+        "summary": "Create Test Instruction",
+        "description": "Debug endpoint to create test instructions",
+        "operationId": "create_test_instruction_debug_session__session_id__create_instruction_post",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Instruction Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/sessions/create": {
+      "post": {
+        "summary": "Create Test Session",
+        "description": "Debug endpoint to create test sessions",
+        "operationId": "create_test_session_debug_sessions_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Session Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grid/{grid_uuid}/model_weights": {
+      "get": {
+        "summary": "Get Model Weights For Grid",
+        "description": "Get time series of model weights for grid",
+        "operationId": "get_model_weights_for_grid_grid__grid_uuid__model_weights_get",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/QualityPredictionModelWeight"
+                    }
+                  },
+                  "title": "Response Get Model Weights For Grid Grid  Grid Uuid  Model Weights Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quality_metric/{metric_name}/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
+      "get": {
+        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare For Metric",
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_for_metric_quality_metric__metric_name__gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
+        "parameters": [
+          {
+            "name": "metric_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Metric Name"
+            }
+          },
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/QualityPrediction"
+                      }
+                    }
+                  },
+                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare For Metric Quality Metric  Metric Name  Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/prediction": {
+      "get": {
+        "summary": "Get Prediction For Gridsquare",
+        "operationId": "get_prediction_for_gridsquare_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__prediction_get",
+        "parameters": [
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionResponse"
+                  },
+                  "title": "Response Get Prediction For Gridsquare Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Prediction Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquare/{gridsquare_uuid}/overall_prediction": {
+      "get": {
+        "summary": "Get Overall Prediction For Gridsquare",
+        "operationId": "get_overall_prediction_for_gridsquare_gridsquare__gridsquare_uuid__overall_prediction_get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OverallQualityPrediction"
+                  },
+                  "title": "Response Get Overall Prediction For Gridsquare Gridsquare  Gridsquare Uuid  Overall Prediction Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grid/{grid_uuid}/prediction_model/{prediction_model_name}/latent_rep/{latent_rep_model_name}/suggested_squares": {
+      "get": {
+        "summary": "Get Suggested Square Collections",
+        "operationId": "get_suggested_square_collections_grid__grid_uuid__prediction_model__prediction_model_name__latent_rep__latent_rep_model_name__suggested_squares_get",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          },
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "latent_rep_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Latent Rep Model Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquare"
+                  },
+                  "title": "Response Get Suggested Square Collections Grid  Grid Uuid  Prediction Model  Prediction Model Name  Latent Rep  Latent Rep Model Name  Suggested Squares Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/latent_representation": {
+      "get": {
+        "summary": "Get Square Latent Rep",
+        "operationId": "get_square_latent_rep_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__latent_representation_get",
+        "parameters": [
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LatentRepresentationResponse"
+                  },
+                  "title": "Response Get Square Latent Rep Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Latent Representation Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grids/{grid_uuid}/atlas_image": {
+      "get": {
+        "summary": "Get Grid Atlas Image",
+        "description": "Get a single grid by ID",
+        "operationId": "get_grid_atlas_image_grids__grid_uuid__atlas_image_get",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          },
+          {
+            "name": "x",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X"
+            }
+          },
+          {
+            "name": "y",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Y"
+            }
+          },
+          {
+            "name": "w",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "W"
+            }
+          },
+          {
+            "name": "h",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "H"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "image/png": {}
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/gridsquare_image": {
+      "get": {
+        "summary": "Get Gridsquare Image",
+        "description": "Get a single grid square by ID",
+        "operationId": "get_gridsquare_image_gridsquares__gridsquare_uuid__gridsquare_image_get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "image/png": {}
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/logs": {
+      "post": {
+        "summary": "Ingest Agent Logs",
+        "operationId": "ingest_agent_logs_agent__agent_id__session__session_id__logs_post",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentLogBatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentLogBatchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/frontend/events/stream": {
+      "get": {
+        "summary": "Frontend Event Stream",
+        "operationId": "frontend_event_stream_frontend_events_stream_get",
+        "parameters": [
+          {
+            "name": "acquisition_uuid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Acquisition Uuid"
+            }
+          },
+          {
+            "name": "agent_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "event_types",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Types"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "components": {
     "schemas": {
       "AcquisitionCreateRequest": {
         "properties": {
-          "atlas_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atlas Path"
-          },
-          "clustering_mode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Clustering Mode"
-          },
-          "clustering_radius": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Clustering Radius"
-          },
-          "computer_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Computer Name"
-          },
-          "end_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "End Time"
-          },
-          "instrument_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Instrument Id"
-          },
-          "instrument_model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Instrument Model"
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
           },
           "name": {
             "anyOf": [
@@ -92,30 +3583,6 @@
             ],
             "title": "Name"
           },
-          "paused_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Paused Time"
-          },
-          "start_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Start Time"
-          },
           "status": {
             "anyOf": [
               {
@@ -125,6 +3592,42 @@
                 "type": "null"
               }
             ]
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "paused_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Time"
           },
           "storage_path": {
             "anyOf": [
@@ -137,19 +3640,6 @@
             ],
             "title": "Storage Path"
           },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
-          }
-        },
-        "required": [
-          "uuid"
-        ],
-        "title": "AcquisitionCreateRequest",
-        "type": "object"
-      },
-      "AcquisitionResponse": {
-        "properties": {
           "atlas_path": {
             "anyOf": [
               {
@@ -183,7 +3673,7 @@
             ],
             "title": "Clustering Radius"
           },
-          "computer_name": {
+          "instrument_model": {
             "anyOf": [
               {
                 "type": "string"
@@ -192,19 +3682,7 @@
                 "type": "null"
               }
             ],
-            "title": "Computer Name"
-          },
-          "end_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "End Time"
+            "title": "Instrument Model"
           },
           "instrument_id": {
             "anyOf": [
@@ -217,7 +3695,7 @@
             ],
             "title": "Instrument Id"
           },
-          "instrument_model": {
+          "computer_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -226,35 +3704,41 @@
                 "type": "null"
               }
             ],
-            "title": "Instrument Model"
+            "title": "Computer Name"
+          }
+        },
+        "type": "object",
+        "required": ["uuid"],
+        "title": "AcquisitionCreateRequest"
+      },
+      "AcquisitionGridCountResponse": {
+        "properties": {
+          "acquisition_uuid": {
+            "type": "string",
+            "title": "Acquisition Uuid"
+          },
+          "grids_total": {
+            "type": "integer",
+            "title": "Grids Total"
+          },
+          "grids_completed": {
+            "type": "integer",
+            "title": "Grids Completed"
+          }
+        },
+        "type": "object",
+        "required": ["acquisition_uuid", "grids_total", "grids_completed"],
+        "title": "AcquisitionGridCountResponse"
+      },
+      "AcquisitionResponse": {
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
           },
           "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "paused_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Paused Time"
-          },
-          "start_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Start Time"
+            "type": "string",
+            "title": "Name"
           },
           "status": {
             "anyOf": [
@@ -265,6 +3749,42 @@
                 "type": "null"
               }
             ]
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "paused_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Time"
           },
           "storage_path": {
             "anyOf": [
@@ -277,11 +3797,74 @@
             ],
             "title": "Storage Path"
           },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
+          "atlas_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Path"
+          },
+          "clustering_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clustering Mode"
+          },
+          "clustering_radius": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clustering Radius"
+          },
+          "instrument_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instrument Model"
+          },
+          "instrument_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instrument Id"
+          },
+          "computer_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Computer Name"
           }
         },
+        "type": "object",
         "required": [
           "uuid",
           "name",
@@ -297,22 +3880,94 @@
           "instrument_id",
           "computer_name"
         ],
-        "title": "AcquisitionResponse",
-        "type": "object"
+        "title": "AcquisitionResponse"
       },
       "AcquisitionStatus": {
-        "enum": [
-          "planned",
-          "started",
-          "completed",
-          "paused",
-          "abandoned"
-        ],
-        "title": "AcquisitionStatus",
-        "type": "string"
+        "type": "string",
+        "enum": ["planned", "started", "completed", "paused", "abandoned"],
+        "title": "AcquisitionStatus"
       },
       "AcquisitionUpdateRequest": {
         "properties": {
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AcquisitionStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "paused_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Time"
+          },
+          "storage_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Path"
+          },
           "atlas_path": {
             "anyOf": [
               {
@@ -346,7 +4001,7 @@
             ],
             "title": "Clustering Radius"
           },
-          "computer_name": {
+          "instrument_model": {
             "anyOf": [
               {
                 "type": "string"
@@ -355,19 +4010,7 @@
                 "type": "null"
               }
             ],
-            "title": "Computer Name"
-          },
-          "end_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "End Time"
+            "title": "Instrument Model"
           },
           "instrument_id": {
             "anyOf": [
@@ -380,7 +4023,7 @@
             ],
             "title": "Instrument Id"
           },
-          "instrument_model": {
+          "computer_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -389,116 +4032,18 @@
                 "type": "null"
               }
             ],
-            "title": "Instrument Model"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "paused_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Paused Time"
-          },
-          "start_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Start Time"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/AcquisitionStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "storage_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Storage Path"
-          },
-          "uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uuid"
+            "title": "Computer Name"
           }
         },
-        "title": "AcquisitionUpdateRequest",
-        "type": "object"
+        "type": "object",
+        "title": "AcquisitionUpdateRequest"
       },
       "AgentInstructionAcknowledgement": {
-        "additionalProperties": false,
-        "description": "Request model for instruction acknowledgements from agents",
         "properties": {
-          "error_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error Message"
-          },
-          "processed_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Processed At"
-          },
-          "processing_time_ms": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Processing Time Ms"
+          "status": {
+            "type": "string",
+            "enum": ["received", "processed", "failed", "declined"],
+            "title": "Status"
           },
           "result": {
             "anyOf": [
@@ -511,70 +4056,129 @@
             ],
             "title": "Result"
           },
-          "status": {
-            "enum": [
-              "received",
-              "processed",
-              "failed",
-              "declined"
-            ],
-            "title": "Status",
-            "type": "string"
-          }
-        },
-        "required": [
-          "status"
-        ],
-        "title": "AgentInstructionAcknowledgement",
-        "type": "object"
-      },
-      "AgentInstructionAcknowledgementResponse": {
-        "description": "Response model for instruction acknowledgement confirmations",
-        "properties": {
-          "acknowledged_at": {
-            "title": "Acknowledged At",
-            "type": "string"
-          },
-          "agent_id": {
-            "title": "Agent Id",
-            "type": "string"
-          },
-          "instruction_id": {
-            "title": "Instruction Id",
-            "type": "string"
-          },
-          "session_id": {
-            "title": "Session Id",
-            "type": "string"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
-          }
-        },
-        "required": [
-          "status",
-          "instruction_id",
-          "acknowledged_at",
-          "agent_id",
-          "session_id"
-        ],
-        "title": "AgentInstructionAcknowledgementResponse",
-        "type": "object"
-      },
-      "AtlasCreateRequest": {
-        "properties": {
-          "acquisition_date": {
+          "error_message": {
             "anyOf": [
               {
-                "format": "date-time",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Acquisition Date"
+            "title": "Error Message"
+          },
+          "processing_time_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processing Time Ms"
+          },
+          "processed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processed At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["status"],
+        "title": "AgentInstructionAcknowledgement",
+        "description": "Request model for instruction acknowledgements from agents"
+      },
+      "AgentInstructionAcknowledgementResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "instruction_id": {
+            "type": "string",
+            "title": "Instruction Id"
+          },
+          "acknowledged_at": {
+            "type": "string",
+            "title": "Acknowledged At"
+          },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          }
+        },
+        "type": "object",
+        "required": ["status", "instruction_id", "acknowledged_at", "agent_id", "session_id"],
+        "title": "AgentInstructionAcknowledgementResponse",
+        "description": "Response model for instruction acknowledgement confirmations"
+      },
+      "AgentLogBatchRequest": {
+        "properties": {
+          "logs": {
+            "items": {
+              "$ref": "#/components/schemas/AgentLogEntry"
+            },
+            "type": "array",
+            "title": "Logs"
+          }
+        },
+        "type": "object",
+        "required": ["logs"],
+        "title": "AgentLogBatchRequest"
+      },
+      "AgentLogBatchResponse": {
+        "properties": {
+          "stored": {
+            "type": "integer",
+            "title": "Stored"
+          }
+        },
+        "type": "object",
+        "required": ["stored"],
+        "title": "AgentLogBatchResponse"
+      },
+      "AgentLogEntry": {
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "level": {
+            "type": "string",
+            "title": "Level"
+          },
+          "logger_name": {
+            "type": "string",
+            "title": "Logger Name"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": ["timestamp", "level", "logger_name", "message"],
+        "title": "AgentLogEntry"
+      },
+      "AtlasCreateRequest": {
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
           },
           "atlas_id": {
             "anyOf": [
@@ -587,24 +4191,21 @@
             ],
             "title": "Atlas Id"
           },
-          "description": {
+          "grid_uuid": {
+            "type": "string",
+            "title": "Grid Uuid"
+          },
+          "acquisition_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Description"
-          },
-          "grid_uuid": {
-            "title": "Grid Uuid",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
+            "title": "Acquisition Date"
           },
           "storage_folder": {
             "anyOf": [
@@ -616,6 +4217,21 @@
               }
             ],
             "title": "Storage Folder"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
           },
           "tiles": {
             "anyOf": [
@@ -630,27 +4246,31 @@
               }
             ],
             "title": "Tiles"
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
           }
         },
-        "required": [
-          "uuid",
-          "grid_uuid",
-          "name"
-        ],
-        "title": "AtlasCreateRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["uuid", "grid_uuid", "name"],
+        "title": "AtlasCreateRequest"
       },
       "AtlasResponse": {
         "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
+          },
+          "grid_uuid": {
+            "type": "string",
+            "title": "Grid Uuid"
+          },
+          "atlas_id": {
+            "type": "string",
+            "title": "Atlas Id"
+          },
           "acquisition_date": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -658,9 +4278,16 @@
             ],
             "title": "Acquisition Date"
           },
-          "atlas_id": {
-            "title": "Atlas Id",
-            "type": "string"
+          "storage_folder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Folder"
           },
           "description": {
             "anyOf": [
@@ -673,24 +4300,9 @@
             ],
             "title": "Description"
           },
-          "grid_uuid": {
-            "title": "Grid Uuid",
-            "type": "string"
-          },
           "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "storage_folder": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Storage Folder"
+            "type": "string",
+            "title": "Name"
           },
           "tiles": {
             "anyOf": [
@@ -704,14 +4316,11 @@
                 "type": "null"
               }
             ],
-            "default": [],
-            "title": "Tiles"
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
+            "title": "Tiles",
+            "default": []
           }
         },
+        "type": "object",
         "required": [
           "uuid",
           "grid_uuid",
@@ -721,80 +4330,13 @@
           "description",
           "name"
         ],
-        "title": "AtlasResponse",
-        "type": "object"
+        "title": "AtlasResponse"
       },
       "AtlasTileCreateRequest": {
         "properties": {
-          "atlas_uuid": {
-            "title": "Atlas Uuid",
-            "type": "string"
-          },
-          "base_filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Base Filename"
-          },
-          "file_format": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "File Format"
-          },
-          "position_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Position X"
-          },
-          "position_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Position Y"
-          },
-          "size_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size X"
-          },
-          "size_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Y"
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
           },
           "tile_id": {
             "anyOf": [
@@ -807,61 +4349,60 @@
             ],
             "title": "Tile Id"
           },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
-          }
-        },
-        "required": [
-          "uuid",
-          "atlas_uuid"
-        ],
-        "title": "AtlasTileCreateRequest",
-        "type": "object"
-      },
-      "AtlasTileGridSquarePositionResponse": {
-        "properties": {
-          "atlastile_uuid": {
-            "title": "Atlastile Uuid",
-            "type": "string"
+          "position_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position X"
           },
-          "center_x": {
-            "title": "Center X",
-            "type": "integer"
+          "position_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position Y"
           },
-          "center_y": {
-            "title": "Center Y",
-            "type": "integer"
+          "size_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size X"
           },
-          "gridsquare_uuid": {
-            "title": "Gridsquare Uuid",
-            "type": "string"
+          "size_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Y"
           },
-          "size_height": {
-            "title": "Size Height",
-            "type": "integer"
-          },
-          "size_width": {
-            "title": "Size Width",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "atlastile_uuid",
-          "gridsquare_uuid",
-          "center_x",
-          "center_y",
-          "size_width",
-          "size_height"
-        ],
-        "title": "AtlasTileGridSquarePositionResponse",
-        "type": "object"
-      },
-      "AtlasTileResponse": {
-        "properties": {
-          "atlas_uuid": {
-            "title": "Atlas Uuid",
-            "type": "string"
+          "file_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Format"
           },
           "base_filename": {
             "anyOf": [
@@ -874,16 +4415,66 @@
             ],
             "title": "Base Filename"
           },
-          "file_format": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "File Format"
+          "atlas_uuid": {
+            "type": "string",
+            "title": "Atlas Uuid"
+          }
+        },
+        "type": "object",
+        "required": ["uuid", "atlas_uuid"],
+        "title": "AtlasTileCreateRequest"
+      },
+      "AtlasTileGridSquarePositionResponse": {
+        "properties": {
+          "atlastile_uuid": {
+            "type": "string",
+            "title": "Atlastile Uuid"
+          },
+          "gridsquare_uuid": {
+            "type": "string",
+            "title": "Gridsquare Uuid"
+          },
+          "center_x": {
+            "type": "integer",
+            "title": "Center X"
+          },
+          "center_y": {
+            "type": "integer",
+            "title": "Center Y"
+          },
+          "size_width": {
+            "type": "integer",
+            "title": "Size Width"
+          },
+          "size_height": {
+            "type": "integer",
+            "title": "Size Height"
+          }
+        },
+        "type": "object",
+        "required": [
+          "atlastile_uuid",
+          "gridsquare_uuid",
+          "center_x",
+          "center_y",
+          "size_width",
+          "size_height"
+        ],
+        "title": "AtlasTileGridSquarePositionResponse"
+      },
+      "AtlasTileResponse": {
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
+          },
+          "atlas_uuid": {
+            "type": "string",
+            "title": "Atlas Uuid"
+          },
+          "tile_id": {
+            "type": "string",
+            "title": "Tile Id"
           },
           "position_x": {
             "anyOf": [
@@ -929,15 +4520,30 @@
             ],
             "title": "Size Y"
           },
-          "tile_id": {
-            "title": "Tile Id",
-            "type": "string"
+          "file_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Format"
           },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
+          "base_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Filename"
           }
         },
+        "type": "object",
         "required": [
           "uuid",
           "atlas_uuid",
@@ -949,12 +4555,11 @@
           "file_format",
           "base_filename"
         ],
-        "title": "AtlasTileResponse",
-        "type": "object"
+        "title": "AtlasTileResponse"
       },
       "AtlasTileUpdateRequest": {
         "properties": {
-          "atlas_uuid": {
+          "uuid": {
             "anyOf": [
               {
                 "type": "string"
@@ -963,9 +4568,9 @@
                 "type": "null"
               }
             ],
-            "title": "Atlas Uuid"
+            "title": "Uuid"
           },
-          "base_filename": {
+          "tile_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -974,18 +4579,7 @@
                 "type": "null"
               }
             ],
-            "title": "Base Filename"
-          },
-          "file_format": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "File Format"
+            "title": "Tile Id"
           },
           "position_x": {
             "anyOf": [
@@ -1031,7 +4625,7 @@
             ],
             "title": "Size Y"
           },
-          "tile_id": {
+          "file_format": {
             "anyOf": [
               {
                 "type": "string"
@@ -1040,8 +4634,36 @@
                 "type": "null"
               }
             ],
-            "title": "Tile Id"
+            "title": "File Format"
           },
+          "base_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Filename"
+          },
+          "atlas_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Uuid"
+          }
+        },
+        "type": "object",
+        "title": "AtlasTileUpdateRequest"
+      },
+      "AtlasUpdateRequest": {
+        "properties": {
           "uuid": {
             "anyOf": [
               {
@@ -1052,24 +4674,6 @@
               }
             ],
             "title": "Uuid"
-          }
-        },
-        "title": "AtlasTileUpdateRequest",
-        "type": "object"
-      },
-      "AtlasUpdateRequest": {
-        "properties": {
-          "acquisition_date": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Date"
           },
           "atlas_id": {
             "anyOf": [
@@ -1082,17 +4686,6 @@
             ],
             "title": "Atlas Id"
           },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
           "grid_uuid": {
             "anyOf": [
               {
@@ -1104,16 +4697,17 @@
             ],
             "title": "Grid Uuid"
           },
-          "name": {
+          "acquisition_date": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Acquisition Date"
           },
           "storage_folder": {
             "anyOf": [
@@ -1126,7 +4720,7 @@
             ],
             "title": "Storage Folder"
           },
-          "uuid": {
+          "description": {
             "anyOf": [
               {
                 "type": "string"
@@ -1135,27 +4729,40 @@
                 "type": "null"
               }
             ],
-            "title": "Uuid"
+            "title": "Description"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
           }
         },
-        "title": "AtlasUpdateRequest",
-        "type": "object"
+        "type": "object",
+        "title": "AtlasUpdateRequest"
       },
       "CtfEstimationCompletedRequest": {
         "properties": {
           "ctf_max_res": {
-            "title": "Ctf Max Res",
-            "type": "number"
+            "type": "number",
+            "title": "Ctf Max Res"
           }
         },
-        "required": [
-          "ctf_max_res"
-        ],
-        "title": "CtfEstimationCompletedRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["ctf_max_res"],
+        "title": "CtfEstimationCompletedRequest"
       },
       "CtfEstimationRegisteredRequest": {
         "properties": {
+          "quality": {
+            "type": "boolean",
+            "title": "Quality"
+          },
           "metric_name": {
             "anyOf": [
               {
@@ -1166,20 +4773,30 @@
               }
             ],
             "title": "Metric Name"
-          },
-          "quality": {
-            "title": "Quality",
-            "type": "boolean"
           }
         },
-        "required": [
-          "quality"
-        ],
-        "title": "CtfEstimationRegisteredRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["quality"],
+        "title": "CtfEstimationRegisteredRequest"
       },
       "FoilHoleCreateRequest": {
         "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
+          },
+          "foilhole_id": {
+            "type": "string",
+            "title": "Foilhole Id"
+          },
+          "gridsquare_id": {
+            "type": "string",
+            "title": "Gridsquare Id"
+          },
+          "gridsquare_uuid": {
+            "type": "string",
+            "title": "Gridsquare Uuid"
+          },
           "center_x": {
             "anyOf": [
               {
@@ -1201,34 +4818,6 @@
               }
             ],
             "title": "Center Y"
-          },
-          "diameter": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Diameter"
-          },
-          "foilhole_id": {
-            "title": "Foilhole Id",
-            "type": "string"
-          },
-          "gridsquare_id": {
-            "title": "Gridsquare Id",
-            "type": "string"
-          },
-          "gridsquare_uuid": {
-            "title": "Gridsquare Uuid",
-            "type": "string"
-          },
-          "is_near_grid_bar": {
-            "default": false,
-            "title": "Is Near Grid Bar",
-            "type": "boolean"
           },
           "quality": {
             "anyOf": [
@@ -1252,17 +4841,6 @@
             ],
             "title": "Rotation"
           },
-          "size_height": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Height"
-          },
           "size_width": {
             "anyOf": [
               {
@@ -1274,19 +4852,16 @@
             ],
             "title": "Size Width"
           },
-          "status": {
+          "size_height": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/FoilHoleStatus"
+                "type": "number"
               },
               {
                 "type": "null"
               }
-            ]
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
+            ],
+            "title": "Size Height"
           },
           "x_location": {
             "anyOf": [
@@ -1299,17 +4874,6 @@
             ],
             "title": "X Location"
           },
-          "x_stage_position": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "X Stage Position"
-          },
           "y_location": {
             "anyOf": [
               {
@@ -1321,6 +4885,17 @@
             ],
             "title": "Y Location"
           },
+          "x_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Stage Position"
+          },
           "y_stage_position": {
             "anyOf": [
               {
@@ -1331,40 +4906,6 @@
               }
             ],
             "title": "Y Stage Position"
-          }
-        },
-        "required": [
-          "uuid",
-          "foilhole_id",
-          "gridsquare_id",
-          "gridsquare_uuid"
-        ],
-        "title": "FoilHoleCreateRequest",
-        "type": "object"
-      },
-      "FoilHoleResponse": {
-        "properties": {
-          "center_x": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center X"
-          },
-          "center_y": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Y"
           },
           "diameter": {
             "anyOf": [
@@ -1377,9 +4918,31 @@
             ],
             "title": "Diameter"
           },
-          "foilhole_id": {
-            "title": "Foilhole Id",
-            "type": "string"
+          "is_near_grid_bar": {
+            "type": "boolean",
+            "title": "Is Near Grid Bar",
+            "default": false
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoilHoleStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": ["uuid", "foilhole_id", "gridsquare_id", "gridsquare_uuid"],
+        "title": "FoilHoleCreateRequest"
+      },
+      "FoilHoleResponse": {
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
           },
           "gridsquare_id": {
             "anyOf": [
@@ -1392,9 +4955,41 @@
             ],
             "title": "Gridsquare Id"
           },
-          "is_near_grid_bar": {
-            "title": "Is Near Grid Bar",
-            "type": "boolean"
+          "foilhole_id": {
+            "type": "string",
+            "title": "Foilhole Id"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoilHoleStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
           },
           "quality": {
             "anyOf": [
@@ -1418,17 +5013,6 @@
             ],
             "title": "Rotation"
           },
-          "size_height": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Height"
-          },
           "size_width": {
             "anyOf": [
               {
@@ -1440,19 +5024,16 @@
             ],
             "title": "Size Width"
           },
-          "status": {
+          "size_height": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/FoilHoleStatus"
+                "type": "number"
               },
               {
                 "type": "null"
               }
-            ]
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
+            ],
+            "title": "Size Height"
           },
           "x_location": {
             "anyOf": [
@@ -1465,17 +5046,6 @@
             ],
             "title": "X Location"
           },
-          "x_stage_position": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "X Stage Position"
-          },
           "y_location": {
             "anyOf": [
               {
@@ -1487,6 +5057,17 @@
             ],
             "title": "Y Location"
           },
+          "x_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Stage Position"
+          },
           "y_stage_position": {
             "anyOf": [
               {
@@ -1497,8 +5078,24 @@
               }
             ],
             "title": "Y Stage Position"
+          },
+          "diameter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diameter"
+          },
+          "is_near_grid_bar": {
+            "type": "boolean",
+            "title": "Is Near Grid Bar"
           }
         },
+        "type": "object",
         "required": [
           "uuid",
           "gridsquare_id",
@@ -1517,51 +5114,25 @@
           "diameter",
           "is_near_grid_bar"
         ],
-        "title": "FoilHoleResponse",
-        "type": "object"
+        "title": "FoilHoleResponse"
       },
       "FoilHoleStatus": {
-        "enum": [
-          "none",
-          "micrographs detected"
-        ],
-        "title": "FoilHoleStatus",
-        "type": "string"
+        "type": "string",
+        "enum": ["none", "micrographs detected"],
+        "title": "FoilHoleStatus"
       },
       "FoilHoleUpdateRequest": {
         "properties": {
-          "center_x": {
+          "uuid": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Center X"
-          },
-          "center_y": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Y"
-          },
-          "diameter": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Diameter"
+            "title": "Uuid"
           },
           "foilhole_id": {
             "anyOf": [
@@ -1596,10 +5167,27 @@
             ],
             "title": "Gridsquare Uuid"
           },
-          "is_near_grid_bar": {
-            "default": false,
-            "title": "Is Near Grid Bar",
-            "type": "boolean"
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
           },
           "quality": {
             "anyOf": [
@@ -1623,17 +5211,6 @@
             ],
             "title": "Rotation"
           },
-          "size_height": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Height"
-          },
           "size_width": {
             "anyOf": [
               {
@@ -1645,26 +5222,16 @@
             ],
             "title": "Size Width"
           },
-          "status": {
+          "size_height": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/FoilHoleStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "uuid": {
-            "anyOf": [
-              {
-                "type": "string"
+                "type": "number"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Uuid"
+            "title": "Size Height"
           },
           "x_location": {
             "anyOf": [
@@ -1677,17 +5244,6 @@
             ],
             "title": "X Location"
           },
-          "x_stage_position": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "X Stage Position"
-          },
           "y_location": {
             "anyOf": [
               {
@@ -1699,6 +5255,17 @@
             ],
             "title": "Y Location"
           },
+          "x_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Stage Position"
+          },
           "y_stage_position": {
             "anyOf": [
               {
@@ -1709,27 +5276,60 @@
               }
             ],
             "title": "Y Stage Position"
-          }
-        },
-        "title": "FoilHoleUpdateRequest",
-        "type": "object"
-      },
-      "GridCreateRequest": {
-        "properties": {
-          "acquisition_uuid": {
-            "title": "Acquisition Uuid",
-            "type": "string"
           },
-          "atlas_dir": {
+          "diameter": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Atlas Dir"
+            "title": "Diameter"
+          },
+          "is_near_grid_bar": {
+            "type": "boolean",
+            "title": "Is Near Grid Bar",
+            "default": false
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoilHoleStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "FoilHoleUpdateRequest"
+      },
+      "GridCreateRequest": {
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "acquisition_uuid": {
+            "type": "string",
+            "title": "Acquisition Uuid"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "data_dir": {
             "anyOf": [
@@ -1742,27 +5342,22 @@
             ],
             "title": "Data Dir"
           },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "scan_end_time": {
+          "atlas_dir": {
             "anyOf": [
               {
-                "format": "date-time",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Scan End Time"
+            "title": "Atlas Dir"
           },
           "scan_start_time": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -1770,31 +5365,29 @@
             ],
             "title": "Scan Start Time"
           },
-          "status": {
+          "scan_end_time": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GridStatus"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
-            ]
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
+            ],
+            "title": "Scan End Time"
           }
         },
-        "required": [
-          "uuid",
-          "name",
-          "acquisition_uuid"
-        ],
-        "title": "GridCreateRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["uuid", "name", "acquisition_uuid"],
+        "title": "GridCreateRequest"
       },
       "GridResponse": {
         "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
+          },
           "acquisition_uuid": {
             "anyOf": [
               {
@@ -1806,6 +5399,31 @@
             ],
             "title": "Acquisition Uuid"
           },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
           "atlas_dir": {
             "anyOf": [
               {
@@ -1817,38 +5435,11 @@
             ],
             "title": "Atlas Dir"
           },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Dir"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "scan_end_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scan End Time"
-          },
           "scan_start_time": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -1856,21 +5447,20 @@
             ],
             "title": "Scan Start Time"
           },
-          "status": {
+          "scan_end_time": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GridStatus"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
-            ]
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
+            ],
+            "title": "Scan End Time"
           }
         },
+        "type": "object",
         "required": [
           "uuid",
           "acquisition_uuid",
@@ -1881,99 +5471,13 @@
           "scan_start_time",
           "scan_end_time"
         ],
-        "title": "GridResponse",
-        "type": "object"
+        "title": "GridResponse"
       },
       "GridSquare": {
         "properties": {
-          "acquisition_datetime": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Datetime"
-          },
-          "applied_defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Applied Defocus"
-          },
-          "atlas_node_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atlas Node Id"
-          },
-          "center_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center X"
-          },
-          "center_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Y"
-          },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Dir"
-          },
-          "defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Defocus"
-          },
-          "detector_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detector Name"
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
           },
           "grid_uuid": {
             "anyOf": [
@@ -1986,12 +5490,16 @@
             ],
             "title": "Grid Uuid"
           },
-          "gridsquare_id": {
-            "default": "",
-            "title": "Gridsquare Id",
-            "type": "string"
+          "status": {
+            "$ref": "#/components/schemas/GridSquareStatus",
+            "default": "none"
           },
-          "image_path": {
+          "gridsquare_id": {
+            "type": "string",
+            "title": "Gridsquare Id",
+            "default": ""
+          },
+          "data_dir": {
             "anyOf": [
               {
                 "type": "string"
@@ -2000,51 +5508,29 @@
                 "type": "null"
               }
             ],
-            "title": "Image Path"
+            "title": "Data Dir"
           },
-          "magnification": {
+          "atlas_node_id": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Magnification"
+            "title": "Atlas Node Id"
           },
-          "physical_x": {
+          "state": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Physical X"
-          },
-          "physical_y": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Physical Y"
-          },
-          "pixel_size": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pixel Size"
+            "title": "State"
           },
           "rotation": {
             "anyOf": [
@@ -2057,6 +5543,17 @@
             ],
             "title": "Rotation"
           },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
           "selected": {
             "anyOf": [
               {
@@ -2068,27 +5565,16 @@
             ],
             "title": "Selected"
           },
-          "size_height": {
+          "unusable": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Size Height"
-          },
-          "size_width": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Width"
+            "title": "Unusable"
           },
           "stage_position_x": {
             "anyOf": [
@@ -2122,112 +5608,6 @@
               }
             ],
             "title": "Stage Position Z"
-          },
-          "state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "State"
-          },
-          "status": {
-            "$ref": "#/components/schemas/GridSquareStatus",
-            "default": "none"
-          },
-          "unusable": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unusable"
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
-          }
-        },
-        "required": [
-          "uuid"
-        ],
-        "title": "GridSquare",
-        "type": "object"
-      },
-      "GridSquareBatchCreateRequest": {
-        "properties": {
-          "gridsquares": {
-            "items": {
-              "$ref": "#/components/schemas/GridSquareCreateRequest"
-            },
-            "title": "Gridsquares",
-            "type": "array"
-          }
-        },
-        "required": [
-          "gridsquares"
-        ],
-        "title": "GridSquareBatchCreateRequest",
-        "type": "object"
-      },
-      "GridSquareBatchCreateResponse": {
-        "description": "Response for bulk grid-square creation.",
-        "properties": {
-          "gridsquares": {
-            "items": {
-              "$ref": "#/components/schemas/GridSquareResponse"
-            },
-            "title": "Gridsquares",
-            "type": "array"
-          }
-        },
-        "required": [
-          "gridsquares"
-        ],
-        "title": "GridSquareBatchCreateResponse",
-        "type": "object"
-      },
-      "GridSquareCreateRequest": {
-        "properties": {
-          "acquisition_datetime": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Datetime"
-          },
-          "applied_defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Applied Defocus"
-          },
-          "atlas_node_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atlas Node Id"
           },
           "center_x": {
             "anyOf": [
@@ -2251,74 +5631,6 @@
             ],
             "title": "Center Y"
           },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Dir"
-          },
-          "defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Defocus"
-          },
-          "detector_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detector Name"
-          },
-          "grid_uuid": {
-            "title": "Grid Uuid",
-            "type": "string"
-          },
-          "gridsquare_id": {
-            "title": "Gridsquare Id",
-            "type": "string"
-          },
-          "image_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Image Path"
-          },
-          "lowmag": {
-            "default": false,
-            "title": "Lowmag",
-            "type": "boolean"
-          },
-          "magnification": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Magnification"
-          },
           "physical_x": {
             "anyOf": [
               {
@@ -2341,38 +5653,16 @@
             ],
             "title": "Physical Y"
           },
-          "pixel_size": {
+          "size_width": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Pixel Size"
-          },
-          "rotation": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rotation"
-          },
-          "selected": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Selected"
+            "title": "Size Width"
           },
           "size_height": {
             "anyOf": [
@@ -2385,7 +5675,133 @@
             ],
             "title": "Size Height"
           },
-          "size_width": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
+          }
+        },
+        "type": "object",
+        "required": ["uuid"],
+        "title": "GridSquare"
+      },
+      "GridSquareBatchCreateRequest": {
+        "properties": {
+          "gridsquares": {
+            "items": {
+              "$ref": "#/components/schemas/GridSquareCreateRequest"
+            },
+            "type": "array",
+            "title": "Gridsquares"
+          }
+        },
+        "type": "object",
+        "required": ["gridsquares"],
+        "title": "GridSquareBatchCreateRequest"
+      },
+      "GridSquareBatchCreateResponse": {
+        "properties": {
+          "gridsquares": {
+            "items": {
+              "$ref": "#/components/schemas/GridSquareResponse"
+            },
+            "type": "array",
+            "title": "Gridsquares"
+          }
+        },
+        "type": "object",
+        "required": ["gridsquares"],
+        "title": "GridSquareBatchCreateResponse",
+        "description": "Response for bulk grid-square creation."
+      },
+      "GridSquareCreateRequest": {
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
+          },
+          "gridsquare_id": {
+            "type": "string",
+            "title": "Gridsquare Id"
+          },
+          "grid_uuid": {
+            "type": "string",
+            "title": "Grid Uuid"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "atlas_node_id": {
             "anyOf": [
               {
                 "type": "integer"
@@ -2394,7 +5810,62 @@
                 "type": "null"
               }
             ],
-            "title": "Size Width"
+            "title": "Atlas Node Id"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
+          "selected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected"
+          },
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unusable"
           },
           "stage_position_x": {
             "anyOf": [
@@ -2429,7 +5900,118 @@
             ],
             "title": "Stage Position Z"
           },
-          "state": {
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "detector_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -2438,7 +6020,18 @@
                 "type": "null"
               }
             ],
-            "title": "State"
+            "title": "Detector Name"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
           },
           "status": {
             "anyOf": [
@@ -2450,39 +6043,33 @@
               }
             ]
           },
-          "unusable": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unusable"
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
+          "lowmag": {
+            "type": "boolean",
+            "title": "Lowmag",
+            "default": false
           }
         },
-        "required": [
-          "uuid",
-          "gridsquare_id",
-          "grid_uuid"
-        ],
-        "title": "GridSquareCreateRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["uuid", "gridsquare_id", "grid_uuid"],
+        "title": "GridSquareCreateRequest"
       },
       "GridSquarePositionRequest": {
         "properties": {
           "center_x": {
-            "title": "Center X",
-            "type": "integer"
+            "type": "integer",
+            "title": "Center X"
           },
           "center_y": {
-            "title": "Center Y",
-            "type": "integer"
+            "type": "integer",
+            "title": "Center Y"
+          },
+          "size_width": {
+            "type": "integer",
+            "title": "Size Width"
+          },
+          "size_height": {
+            "type": "integer",
+            "title": "Size Height"
           },
           "gridsquare_uuid": {
             "anyOf": [
@@ -2494,115 +6081,21 @@
               }
             ],
             "title": "Gridsquare Uuid"
-          },
-          "size_height": {
-            "title": "Size Height",
-            "type": "integer"
-          },
-          "size_width": {
-            "title": "Size Width",
-            "type": "integer"
           }
         },
-        "required": [
-          "center_x",
-          "center_y",
-          "size_width",
-          "size_height"
-        ],
-        "title": "GridSquarePositionRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["center_x", "center_y", "size_width", "size_height"],
+        "title": "GridSquarePositionRequest"
       },
       "GridSquareResponse": {
         "properties": {
-          "acquisition_datetime": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Datetime"
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
           },
-          "applied_defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Applied Defocus"
-          },
-          "atlas_node_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atlas Node Id"
-          },
-          "center_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center X"
-          },
-          "center_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Y"
-          },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Dir"
-          },
-          "defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Defocus"
-          },
-          "detector_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detector Name"
+          "gridsquare_id": {
+            "type": "string",
+            "title": "Gridsquare Id"
           },
           "grid_uuid": {
             "anyOf": [
@@ -2615,11 +6108,17 @@
             ],
             "title": "Grid Uuid"
           },
-          "gridsquare_id": {
-            "title": "Gridsquare Id",
-            "type": "string"
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridSquareStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
-          "image_path": {
+          "data_dir": {
             "anyOf": [
               {
                 "type": "string"
@@ -2628,51 +6127,29 @@
                 "type": "null"
               }
             ],
-            "title": "Image Path"
+            "title": "Data Dir"
           },
-          "magnification": {
+          "atlas_node_id": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Magnification"
+            "title": "Atlas Node Id"
           },
-          "physical_x": {
+          "state": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Physical X"
-          },
-          "physical_y": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Physical Y"
-          },
-          "pixel_size": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pixel Size"
+            "title": "State"
           },
           "rotation": {
             "anyOf": [
@@ -2685,6 +6162,17 @@
             ],
             "title": "Rotation"
           },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
           "selected": {
             "anyOf": [
               {
@@ -2696,27 +6184,16 @@
             ],
             "title": "Selected"
           },
-          "size_height": {
+          "unusable": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Size Height"
-          },
-          "size_width": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Width"
+            "title": "Unusable"
           },
           "stage_position_x": {
             "anyOf": [
@@ -2751,7 +6228,118 @@
             ],
             "title": "Stage Position Z"
           },
-          "state": {
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "detector_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -2760,34 +6348,21 @@
                 "type": "null"
               }
             ],
-            "title": "State"
+            "title": "Detector Name"
           },
-          "status": {
+          "applied_defocus": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GridSquareStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "unusable": {
-            "anyOf": [
-              {
-                "type": "boolean"
+                "type": "number"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Unusable"
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
+            "title": "Applied Defocus"
           }
         },
+        "type": "object",
         "required": [
           "uuid",
           "gridsquare_id",
@@ -2816,78 +6391,21 @@
           "detector_name",
           "applied_defocus"
         ],
-        "title": "GridSquareResponse",
-        "type": "object"
+        "title": "GridSquareResponse"
       },
       "GridSquareStatus": {
+        "type": "string",
         "enum": [
           "none",
           "all foil holes registered",
           "foil holes decision started",
           "foil holes decision completed"
         ],
-        "title": "GridSquareStatus",
-        "type": "string"
+        "title": "GridSquareStatus"
       },
       "GridSquareUpdateRequest": {
         "properties": {
-          "acquisition_datetime": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Datetime"
-          },
-          "applied_defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Applied Defocus"
-          },
-          "atlas_node_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atlas Node Id"
-          },
-          "center_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center X"
-          },
-          "center_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Center Y"
-          },
-          "data_dir": {
+          "uuid": {
             "anyOf": [
               {
                 "type": "string"
@@ -2896,40 +6414,7 @@
                 "type": "null"
               }
             ],
-            "title": "Data Dir"
-          },
-          "defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Defocus"
-          },
-          "detector_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detector Name"
-          },
-          "grid_uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grid Uuid"
+            "title": "Uuid"
           },
           "gridsquare_id": {
             "anyOf": [
@@ -2942,7 +6427,7 @@
             ],
             "title": "Gridsquare Id"
           },
-          "image_path": {
+          "grid_uuid": {
             "anyOf": [
               {
                 "type": "string"
@@ -2951,56 +6436,40 @@
                 "type": "null"
               }
             ],
-            "title": "Image Path"
+            "title": "Grid Uuid"
           },
-          "lowmag": {
-            "default": false,
-            "title": "Lowmag",
-            "type": "boolean"
-          },
-          "magnification": {
+          "data_dir": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Magnification"
+            "title": "Data Dir"
           },
-          "physical_x": {
+          "atlas_node_id": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Physical X"
+            "title": "Atlas Node Id"
           },
-          "physical_y": {
+          "state": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Physical Y"
-          },
-          "pixel_size": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pixel Size"
+            "title": "State"
           },
           "rotation": {
             "anyOf": [
@@ -3013,6 +6482,17 @@
             ],
             "title": "Rotation"
           },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
           "selected": {
             "anyOf": [
               {
@@ -3024,27 +6504,16 @@
             ],
             "title": "Selected"
           },
-          "size_height": {
+          "unusable": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Size Height"
-          },
-          "size_width": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Width"
+            "title": "Unusable"
           },
           "stage_position_x": {
             "anyOf": [
@@ -3079,7 +6548,118 @@
             ],
             "title": "Stage Position Z"
           },
-          "state": {
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "detector_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -3088,7 +6668,18 @@
                 "type": "null"
               }
             ],
-            "title": "State"
+            "title": "Detector Name"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
           },
           "status": {
             "anyOf": [
@@ -3100,17 +6691,28 @@
               }
             ]
           },
-          "unusable": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unusable"
-          },
+          "lowmag": {
+            "type": "boolean",
+            "title": "Lowmag",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "GridSquareUpdateRequest"
+      },
+      "GridStatus": {
+        "type": "string",
+        "enum": [
+          "none",
+          "scan started",
+          "scan completed",
+          "grid squares decision started",
+          "grid squares decision completed"
+        ],
+        "title": "GridStatus"
+      },
+      "GridUpdateRequest": {
+        "properties": {
           "uuid": {
             "anyOf": [
               {
@@ -3121,56 +6723,6 @@
               }
             ],
             "title": "Uuid"
-          }
-        },
-        "title": "GridSquareUpdateRequest",
-        "type": "object"
-      },
-      "GridStatus": {
-        "enum": [
-          "none",
-          "scan started",
-          "scan completed",
-          "grid squares decision started",
-          "grid squares decision completed"
-        ],
-        "title": "GridStatus",
-        "type": "string"
-      },
-      "GridUpdateRequest": {
-        "properties": {
-          "acquisition_uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Uuid"
-          },
-          "atlas_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atlas Dir"
-          },
-          "data_dir": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Dir"
           },
           "name": {
             "anyOf": [
@@ -3183,29 +6735,16 @@
             ],
             "title": "Name"
           },
-          "scan_end_time": {
+          "acquisition_uuid": {
             "anyOf": [
               {
-                "format": "date-time",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Scan End Time"
-          },
-          "scan_start_time": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scan Start Time"
+            "title": "Acquisition Uuid"
           },
           "status": {
             "anyOf": [
@@ -3217,7 +6756,7 @@
               }
             ]
           },
-          "uuid": {
+          "data_dir": {
             "anyOf": [
               {
                 "type": "string"
@@ -3226,11 +6765,46 @@
                 "type": "null"
               }
             ],
-            "title": "Uuid"
+            "title": "Data Dir"
+          },
+          "atlas_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Dir"
+          },
+          "scan_start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan Start Time"
+          },
+          "scan_end_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan End Time"
           }
         },
-        "title": "GridUpdateRequest",
-        "type": "object"
+        "type": "object",
+        "title": "GridUpdateRequest"
       },
       "HTTPValidationError": {
         "properties": {
@@ -3238,36 +6812,15 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             },
-            "title": "Detail",
-            "type": "array"
+            "type": "array",
+            "title": "Detail"
           }
         },
-        "title": "HTTPValidationError",
-        "type": "object"
+        "type": "object",
+        "title": "HTTPValidationError"
       },
       "LatentRepresentationResponse": {
         "properties": {
-          "foilhole_uuid": {
-            "default": "",
-            "title": "Foilhole Uuid",
-            "type": "string"
-          },
-          "gridsquare_uuid": {
-            "default": "",
-            "title": "Gridsquare Uuid",
-            "type": "string"
-          },
-          "index": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Index"
-          },
           "x": {
             "anyOf": [
               {
@@ -3289,110 +6842,38 @@
               }
             ],
             "title": "Y"
+          },
+          "index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index"
+          },
+          "gridsquare_uuid": {
+            "type": "string",
+            "title": "Gridsquare Uuid",
+            "default": ""
+          },
+          "foilhole_uuid": {
+            "type": "string",
+            "title": "Foilhole Uuid",
+            "default": ""
           }
         },
-        "required": [
-          "x",
-          "y",
-          "index"
-        ],
-        "title": "LatentRepresentationResponse",
-        "type": "object"
+        "type": "object",
+        "required": ["x", "y", "index"],
+        "title": "LatentRepresentationResponse"
       },
       "MicrographCreateRequest": {
         "properties": {
-          "acquisition_datetime": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Acquisition Datetime"
-          },
-          "average_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Average Motion"
-          },
-          "binning_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning X"
-          },
-          "binning_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning Y"
-          },
-          "ctf_max_resolution_estimate": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ctf Max Resolution Estimate"
-          },
-          "defocus": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Defocus"
-          },
-          "detector_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detector Name"
-          },
-          "energy_filter": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Energy Filter"
-          },
-          "foilhole_id": {
-            "title": "Foilhole Id",
-            "type": "string"
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
           },
           "foilhole_uuid": {
             "anyOf": [
@@ -3405,38 +6886,9 @@
             ],
             "title": "Foilhole Uuid"
           },
-          "high_res_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "High Res Path"
-          },
-          "image_size_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Image Size X"
-          },
-          "image_size_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Image Size Y"
+          "foilhole_id": {
+            "type": "string",
+            "title": "Foilhole Id"
           },
           "location_id": {
             "anyOf": [
@@ -3449,6 +6901,17 @@
             ],
             "title": "Location Id"
           },
+          "high_res_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "High Res Path"
+          },
           "manifest_file": {
             "anyOf": [
               {
@@ -3460,156 +6923,17 @@
             ],
             "title": "Manifest File"
           },
-          "number_of_particles_picked": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Picked"
-          },
-          "number_of_particles_rejected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Rejected"
-          },
-          "number_of_particles_selected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Selected"
-          },
-          "phase_plate": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phase Plate"
-          },
-          "pick_distribution": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pick Distribution"
-          },
-          "selection_distribution": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Selection Distribution"
-          },
-          "status": {
-            "$ref": "#/components/schemas/MicrographStatus",
-            "default": "none"
-          },
-          "total_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Motion"
-          },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
-          }
-        },
-        "required": [
-          "uuid",
-          "foilhole_id"
-        ],
-        "title": "MicrographCreateRequest",
-        "type": "object"
-      },
-      "MicrographResponse": {
-        "properties": {
           "acquisition_datetime": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Acquisition Datetime"
-          },
-          "average_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Average Motion"
-          },
-          "binning_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning X"
-          },
-          "binning_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning Y"
-          },
-          "ctf_max_resolution_estimate": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ctf Max Resolution Estimate"
           },
           "defocus": {
             "anyOf": [
@@ -3644,31 +6968,16 @@
             ],
             "title": "Energy Filter"
           },
-          "foilhole_id": {
+          "phase_plate": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Foilhole Id"
-          },
-          "foilhole_uuid": {
-            "title": "Foilhole Uuid",
-            "type": "string"
-          },
-          "high_res_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "High Res Path"
+            "title": "Phase Plate"
           },
           "image_size_x": {
             "anyOf": [
@@ -3692,18 +7001,84 @@
             ],
             "title": "Image Size Y"
           },
-          "location_id": {
+          "binning_x": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Location Id"
+            "title": "Binning X"
           },
-          "manifest_file": {
+          "binning_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning Y"
+          },
+          "total_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Motion"
+          },
+          "average_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Motion"
+          },
+          "ctf_max_resolution_estimate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ctf Max Resolution Estimate"
+          },
+          "number_of_particles_selected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Selected"
+          },
+          "number_of_particles_rejected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Rejected"
+          },
+          "selection_distribution": {
             "anyOf": [
               {
                 "type": "string"
@@ -3712,7 +7087,59 @@
                 "type": "null"
               }
             ],
-            "title": "Manifest File"
+            "title": "Selection Distribution"
+          },
+          "number_of_particles_picked": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Picked"
+          },
+          "pick_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pick Distribution"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MicrographStatus",
+            "default": "none"
+          }
+        },
+        "type": "object",
+        "required": ["uuid", "foilhole_id"],
+        "title": "MicrographCreateRequest"
+      },
+      "MicrographResponse": {
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
+          },
+          "foilhole_uuid": {
+            "type": "string",
+            "title": "Foilhole Uuid"
+          },
+          "foilhole_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Id"
           },
           "micrograph_id": {
             "anyOf": [
@@ -3725,51 +7152,7 @@
             ],
             "title": "Micrograph Id"
           },
-          "number_of_particles_picked": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Picked"
-          },
-          "number_of_particles_rejected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Rejected"
-          },
-          "number_of_particles_selected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Selected"
-          },
-          "phase_plate": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phase Plate"
-          },
-          "pick_distribution": {
+          "location_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -3778,118 +7161,44 @@
                 "type": "null"
               }
             ],
-            "title": "Pick Distribution"
-          },
-          "selection_distribution": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Selection Distribution"
+            "title": "Location Id"
           },
           "status": {
             "$ref": "#/components/schemas/MicrographStatus"
           },
-          "total_motion": {
+          "high_res_path": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Total Motion"
+            "title": "High Res Path"
           },
-          "uuid": {
-            "title": "Uuid",
-            "type": "string"
-          }
-        },
-        "required": [
-          "uuid",
-          "foilhole_uuid",
-          "status"
-        ],
-        "title": "MicrographResponse",
-        "type": "object"
-      },
-      "MicrographStatus": {
-        "enum": [
-          "none",
-          "motion correction started",
-          "motion correction completed",
-          "ctf started",
-          "ctf completed",
-          "particle picking started",
-          "particle picking completed",
-          "particle selection started",
-          "particle selection completed"
-        ],
-        "title": "MicrographStatus",
-        "type": "string"
-      },
-      "MicrographUpdateRequest": {
-        "properties": {
+          "manifest_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manifest File"
+          },
           "acquisition_datetime": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Acquisition Datetime"
-          },
-          "average_motion": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Average Motion"
-          },
-          "binning_x": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning X"
-          },
-          "binning_y": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binning Y"
-          },
-          "ctf_max_resolution_estimate": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ctf Max Resolution Estimate"
           },
           "defocus": {
             "anyOf": [
@@ -3924,38 +7233,16 @@
             ],
             "title": "Energy Filter"
           },
-          "foilhole_id": {
+          "phase_plate": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Foilhole Id"
-          },
-          "foilhole_uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Foilhole Uuid"
-          },
-          "high_res_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "High Res Path"
+            "title": "Phase Plate"
           },
           "image_size_x": {
             "anyOf": [
@@ -3979,29 +7266,7 @@
             ],
             "title": "Image Size Y"
           },
-          "location_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Location Id"
-          },
-          "manifest_file": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manifest File"
-          },
-          "number_of_particles_picked": {
+          "binning_x": {
             "anyOf": [
               {
                 "type": "integer"
@@ -4010,9 +7275,9 @@
                 "type": "null"
               }
             ],
-            "title": "Number Of Particles Picked"
+            "title": "Binning X"
           },
-          "number_of_particles_rejected": {
+          "binning_y": {
             "anyOf": [
               {
                 "type": "integer"
@@ -4021,55 +7286,7 @@
                 "type": "null"
               }
             ],
-            "title": "Number Of Particles Rejected"
-          },
-          "number_of_particles_selected": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Number Of Particles Selected"
-          },
-          "phase_plate": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phase Plate"
-          },
-          "pick_distribution": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pick Distribution"
-          },
-          "selection_distribution": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Selection Distribution"
-          },
-          "status": {
-            "$ref": "#/components/schemas/MicrographStatus",
-            "default": "none"
+            "title": "Binning Y"
           },
           "total_motion": {
             "anyOf": [
@@ -4082,6 +7299,105 @@
             ],
             "title": "Total Motion"
           },
+          "average_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Motion"
+          },
+          "ctf_max_resolution_estimate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ctf Max Resolution Estimate"
+          },
+          "number_of_particles_selected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Selected"
+          },
+          "number_of_particles_rejected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Rejected"
+          },
+          "selection_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection Distribution"
+          },
+          "number_of_particles_picked": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Picked"
+          },
+          "pick_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pick Distribution"
+          }
+        },
+        "type": "object",
+        "required": ["uuid", "foilhole_uuid", "status"],
+        "title": "MicrographResponse"
+      },
+      "MicrographStatus": {
+        "type": "string",
+        "enum": [
+          "none",
+          "motion correction started",
+          "motion correction completed",
+          "ctf started",
+          "ctf completed",
+          "particle picking started",
+          "particle picking completed",
+          "particle selection started",
+          "particle selection completed"
+        ],
+        "title": "MicrographStatus"
+      },
+      "MicrographUpdateRequest": {
+        "properties": {
           "uuid": {
             "anyOf": [
               {
@@ -4092,31 +7408,279 @@
               }
             ],
             "title": "Uuid"
+          },
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "foilhole_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Id"
+          },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          },
+          "high_res_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "High Res Path"
+          },
+          "manifest_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manifest File"
+          },
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "energy_filter": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy Filter"
+          },
+          "phase_plate": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase Plate"
+          },
+          "image_size_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size X"
+          },
+          "image_size_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size Y"
+          },
+          "binning_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning X"
+          },
+          "binning_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning Y"
+          },
+          "total_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Motion"
+          },
+          "average_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Motion"
+          },
+          "ctf_max_resolution_estimate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ctf Max Resolution Estimate"
+          },
+          "number_of_particles_selected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Selected"
+          },
+          "number_of_particles_rejected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Rejected"
+          },
+          "selection_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection Distribution"
+          },
+          "number_of_particles_picked": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Picked"
+          },
+          "pick_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pick Distribution"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MicrographStatus",
+            "default": "none"
           }
         },
-        "title": "MicrographUpdateRequest",
-        "type": "object"
+        "type": "object",
+        "title": "MicrographUpdateRequest"
       },
       "MotionCorrectionCompletedRequest": {
         "properties": {
-          "average_motion": {
-            "title": "Average Motion",
-            "type": "number"
-          },
           "total_motion": {
-            "title": "Total Motion",
-            "type": "number"
+            "type": "number",
+            "title": "Total Motion"
+          },
+          "average_motion": {
+            "type": "number",
+            "title": "Average Motion"
           }
         },
-        "required": [
-          "total_motion",
-          "average_motion"
-        ],
-        "title": "MotionCorrectionCompletedRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["total_motion", "average_motion"],
+        "title": "MotionCorrectionCompletedRequest"
       },
       "MotionCorrectionRegisteredRequest": {
         "properties": {
+          "quality": {
+            "type": "boolean",
+            "title": "Quality"
+          },
           "metric_name": {
             "anyOf": [
               {
@@ -4127,32 +7691,14 @@
               }
             ],
             "title": "Metric Name"
-          },
-          "quality": {
-            "title": "Quality",
-            "type": "boolean"
           }
         },
-        "required": [
-          "quality"
-        ],
-        "title": "MotionCorrectionRegisteredRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["quality"],
+        "title": "MotionCorrectionRegisteredRequest"
       },
       "OverallQualityPrediction": {
         "properties": {
-          "foilhole_uuid": {
-            "title": "Foilhole Uuid",
-            "type": "string"
-          },
-          "grid_uuid": {
-            "title": "Grid Uuid",
-            "type": "string"
-          },
-          "gridsquare_uuid": {
-            "title": "Gridsquare Uuid",
-            "type": "string"
-          },
           "id": {
             "anyOf": [
               {
@@ -4164,15 +7710,28 @@
             ],
             "title": "Id"
           },
-          "suggested_acquisition_index": {
-            "title": "Suggested Acquisition Index",
-            "type": "integer"
-          },
           "value": {
-            "title": "Value",
-            "type": "number"
+            "type": "number",
+            "title": "Value"
+          },
+          "suggested_acquisition_index": {
+            "type": "integer",
+            "title": "Suggested Acquisition Index"
+          },
+          "foilhole_uuid": {
+            "type": "string",
+            "title": "Foilhole Uuid"
+          },
+          "grid_uuid": {
+            "type": "string",
+            "title": "Grid Uuid"
+          },
+          "gridsquare_uuid": {
+            "type": "string",
+            "title": "Gridsquare Uuid"
           }
         },
+        "type": "object",
         "required": [
           "value",
           "suggested_acquisition_index",
@@ -4180,25 +7739,26 @@
           "grid_uuid",
           "gridsquare_uuid"
         ],
-        "title": "OverallQualityPrediction",
-        "type": "object"
+        "title": "OverallQualityPrediction"
       },
       "ProcessingFeedbackPublishResponse": {
-        "description": "Confirmation that a processing-feedback event was published to RabbitMQ.",
         "properties": {
           "published": {
-            "title": "Published",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Published"
           }
         },
-        "required": [
-          "published"
-        ],
+        "type": "object",
+        "required": ["published"],
         "title": "ProcessingFeedbackPublishResponse",
-        "type": "object"
+        "description": "Confirmation that a processing-feedback event was published to RabbitMQ."
       },
       "QualityMetricsResponse": {
         "properties": {
+          "total_predictions": {
+            "type": "integer",
+            "title": "Total Predictions"
+          },
           "average_quality": {
             "anyOf": [
               {
@@ -4209,17 +7769,6 @@
               }
             ],
             "title": "Average Quality"
-          },
-          "max_quality": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Quality"
           },
           "min_quality": {
             "anyOf": [
@@ -4232,15 +7781,23 @@
             ],
             "title": "Min Quality"
           },
-          "models_count": {
-            "title": "Models Count",
-            "type": "integer"
+          "max_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Quality"
           },
-          "total_predictions": {
-            "title": "Total Predictions",
-            "type": "integer"
+          "models_count": {
+            "type": "integer",
+            "title": "Models Count"
           }
         },
+        "type": "object",
         "required": [
           "total_predictions",
           "average_quality",
@@ -4248,33 +7805,10 @@
           "max_quality",
           "models_count"
         ],
-        "title": "QualityMetricsResponse",
-        "type": "object"
+        "title": "QualityMetricsResponse"
       },
       "QualityPrediction": {
         "properties": {
-          "foilhole_uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Foilhole Uuid"
-          },
-          "gridsquare_uuid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gridsquare Uuid"
-          },
           "id": {
             "anyOf": [
               {
@@ -4285,6 +7819,19 @@
               }
             ],
             "title": "Id"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
           },
           "metric_name": {
             "anyOf": [
@@ -4297,29 +7844,6 @@
             ],
             "title": "Metric Name"
           },
-          "prediction_model_name": {
-            "title": "Prediction Model Name",
-            "type": "string"
-          },
-          "timestamp": {
-            "format": "date-time",
-            "title": "Timestamp",
-            "type": "string"
-          },
-          "value": {
-            "title": "Value",
-            "type": "number"
-          }
-        },
-        "required": [
-          "value",
-          "prediction_model_name"
-        ],
-        "title": "QualityPrediction",
-        "type": "object"
-      },
-      "QualityPredictionCreateRequest": {
-        "properties": {
           "foilhole_uuid": {
             "anyOf": [
               {
@@ -4341,73 +7865,113 @@
               }
             ],
             "title": "Gridsquare Uuid"
-          },
-          "prediction_model_name": {
-            "title": "Prediction Model Name",
-            "type": "string"
-          },
-          "value": {
-            "title": "Value",
-            "type": "number"
           }
         },
-        "required": [
-          "value",
-          "prediction_model_name"
-        ],
-        "title": "QualityPredictionCreateRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["value", "prediction_model_name"],
+        "title": "QualityPrediction"
+      },
+      "QualityPredictionCreateRequest": {
+        "properties": {
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
+          },
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          }
+        },
+        "type": "object",
+        "required": ["value", "prediction_model_name"],
+        "title": "QualityPredictionCreateRequest"
       },
       "QualityPredictionModelCreateRequest": {
         "properties": {
-          "description": {
-            "default": "",
-            "title": "Description",
-            "type": "string"
-          },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": ""
+          },
+          "can_train": {
+            "type": "boolean",
+            "title": "Can Train",
+            "default": false
+          },
+          "can_infer": {
+            "type": "boolean",
+            "title": "Can Infer",
+            "default": true
+          },
+          "can_update": {
+            "type": "boolean",
+            "title": "Can Update",
+            "default": false
           }
         },
-        "required": [
-          "name"
-        ],
-        "title": "QualityPredictionModelCreateRequest",
-        "type": "object"
+        "type": "object",
+        "required": ["name"],
+        "title": "QualityPredictionModelCreateRequest"
       },
       "QualityPredictionModelParameterResponse": {
         "properties": {
-          "grid_uuid": {
-            "title": "Grid Uuid",
-            "type": "string"
-          },
-          "group": {
-            "title": "Group",
-            "type": "string"
-          },
           "id": {
-            "title": "Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Id"
           },
-          "key": {
-            "title": "Key",
-            "type": "string"
-          },
-          "prediction_model_name": {
-            "title": "Prediction Model Name",
-            "type": "string"
+          "grid_uuid": {
+            "type": "string",
+            "title": "Grid Uuid"
           },
           "timestamp": {
+            "type": "string",
             "format": "date-time",
-            "title": "Timestamp",
-            "type": "string"
+            "title": "Timestamp"
+          },
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
           },
           "value": {
-            "title": "Value",
-            "type": "number"
+            "type": "number",
+            "title": "Value"
+          },
+          "group": {
+            "type": "string",
+            "title": "Group"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "grid_uuid",
@@ -4417,26 +7981,34 @@
           "value",
           "group"
         ],
-        "title": "QualityPredictionModelParameterResponse",
-        "type": "object"
+        "title": "QualityPredictionModelParameterResponse"
       },
       "QualityPredictionModelResponse": {
         "properties": {
-          "description": {
-            "title": "Description",
-            "type": "string"
-          },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "can_train": {
+            "type": "boolean",
+            "title": "Can Train"
+          },
+          "can_infer": {
+            "type": "boolean",
+            "title": "Can Infer"
+          },
+          "can_update": {
+            "type": "boolean",
+            "title": "Can Update"
           }
         },
-        "required": [
-          "name",
-          "description"
-        ],
-        "title": "QualityPredictionModelResponse",
-        "type": "object"
+        "type": "object",
+        "required": ["name", "description", "can_train", "can_infer", "can_update"],
+        "title": "QualityPredictionModelResponse"
       },
       "QualityPredictionModelUpdateRequest": {
         "properties": {
@@ -4450,17 +8022,46 @@
               }
             ],
             "title": "Description"
+          },
+          "can_train": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Train"
+          },
+          "can_infer": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Infer"
+          },
+          "can_update": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Update"
           }
         },
-        "title": "QualityPredictionModelUpdateRequest",
-        "type": "object"
+        "type": "object",
+        "title": "QualityPredictionModelUpdateRequest"
       },
       "QualityPredictionModelWeight": {
         "properties": {
-          "grid_uuid": {
-            "title": "Grid Uuid",
-            "type": "string"
-          },
           "id": {
             "anyOf": [
               {
@@ -4472,27 +8073,9 @@
             ],
             "title": "Id"
           },
-          "metric_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Metric Name"
-          },
-          "micrograph_quality": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Micrograph Quality"
+          "grid_uuid": {
+            "type": "string",
+            "title": "Grid Uuid"
           },
           "micrograph_uuid": {
             "anyOf": [
@@ -4505,31 +8088,27 @@
             ],
             "title": "Micrograph Uuid"
           },
-          "prediction_model_name": {
-            "title": "Prediction Model Name",
-            "type": "string"
+          "micrograph_quality": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Micrograph Quality"
           },
           "timestamp": {
+            "type": "string",
             "format": "date-time",
-            "title": "Timestamp",
-            "type": "string"
+            "title": "Timestamp"
           },
-          "weight": {
-            "title": "Weight",
-            "type": "number"
-          }
-        },
-        "required": [
-          "grid_uuid",
-          "prediction_model_name",
-          "weight"
-        ],
-        "title": "QualityPredictionModelWeight",
-        "type": "object"
-      },
-      "QualityPredictionResponse": {
-        "properties": {
-          "foilhole_uuid": {
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
+          },
+          "metric_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -4538,7 +8117,57 @@
                 "type": "null"
               }
             ],
-            "title": "Foilhole Uuid"
+            "title": "Metric Name"
+          },
+          "weight": {
+            "type": "number",
+            "title": "Weight"
+          },
+          "prediction_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prediction Value"
+          },
+          "quality_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Score"
+          }
+        },
+        "type": "object",
+        "required": ["grid_uuid", "prediction_model_name", "weight"],
+        "title": "QualityPredictionModelWeight"
+      },
+      "QualityPredictionResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
+          },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
           },
           "gridsquare_uuid": {
             "anyOf": [
@@ -4551,32 +8180,21 @@
             ],
             "title": "Gridsquare Uuid"
           },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "prediction_model_name": {
-            "title": "Prediction Model Name",
-            "type": "string"
-          },
-          "timestamp": {
-            "format": "date-time",
-            "title": "Timestamp",
-            "type": "string"
-          },
-          "value": {
-            "title": "Value",
-            "type": "number"
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
           }
         },
-        "required": [
-          "id",
-          "prediction_model_name",
-          "value",
-          "timestamp"
-        ],
-        "title": "QualityPredictionResponse",
-        "type": "object"
+        "type": "object",
+        "required": ["id", "prediction_model_name", "value", "timestamp"],
+        "title": "QualityPredictionResponse"
       },
       "ValidationError": {
         "properties": {
@@ -4591,3434 +8209,28 @@
                 }
               ]
             },
-            "title": "Location",
-            "type": "array"
+            "type": "array",
+            "title": "Location"
           },
           "msg": {
-            "title": "Message",
-            "type": "string"
+            "type": "string",
+            "title": "Message"
           },
           "type": {
-            "title": "Error Type",
-            "type": "string"
+            "type": "string",
+            "title": "Error Type"
           }
         },
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "title": "ValidationError",
-        "type": "object"
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
       }
     }
   },
-  "info": {
-    "description": "API for accessing and managing electron microscopy data",
-    "title": "SmartEM Decisions Backend API",
-    "version": "0.1.1rc27.dev13+g15895622a.d20260416"
-  },
-  "openapi": "3.1.0",
-  "paths": {
-    "/acquisitions": {
-      "get": {
-        "description": "Get all acquisitions",
-        "operationId": "get_acquisitions_acquisitions_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AcquisitionResponse"
-                  },
-                  "title": "Response Get Acquisitions Acquisitions Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Acquisitions"
-      },
-      "post": {
-        "description": "Create a new acquisition",
-        "operationId": "create_acquisition_acquisitions_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AcquisitionCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcquisitionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Acquisition"
-      }
-    },
-    "/acquisitions/{acquisition_uuid}": {
-      "delete": {
-        "description": "Delete an acquisition",
-        "operationId": "delete_acquisition_acquisitions__acquisition_uuid__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "acquisition_uuid",
-            "required": true,
-            "schema": {
-              "title": "Acquisition Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Acquisition"
-      },
-      "get": {
-        "description": "Get a single acquisition by ID",
-        "operationId": "get_acquisition_acquisitions__acquisition_uuid__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "acquisition_uuid",
-            "required": true,
-            "schema": {
-              "title": "Acquisition Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcquisitionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Acquisition"
-      },
-      "put": {
-        "description": "Update an acquisition",
-        "operationId": "update_acquisition_acquisitions__acquisition_uuid__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "acquisition_uuid",
-            "required": true,
-            "schema": {
-              "title": "Acquisition Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AcquisitionUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcquisitionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Acquisition"
-      }
-    },
-    "/acquisitions/{acquisition_uuid}/grids": {
-      "get": {
-        "description": "Get all grids for a specific acquisition",
-        "operationId": "get_acquisition_grids_acquisitions__acquisition_uuid__grids_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "acquisition_uuid",
-            "required": true,
-            "schema": {
-              "title": "Acquisition Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GridResponse"
-                  },
-                  "title": "Response Get Acquisition Grids Acquisitions  Acquisition Uuid  Grids Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Acquisition Grids"
-      },
-      "post": {
-        "description": "Create a new grid for a specific acquisition",
-        "operationId": "create_acquisition_grid_acquisitions__acquisition_uuid__grids_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "acquisition_uuid",
-            "required": true,
-            "schema": {
-              "title": "Acquisition Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Acquisition Grid"
-      }
-    },
-    "/agent/{agent_id}/session/{session_id}/heartbeat": {
-      "post": {
-        "description": "Agent heartbeat endpoint to update connection health status.\n\nArgs:\n    agent_id: The agent identifier\n    session_id: The session identifier\n    db: Database session\n\nReturns:\n    Heartbeat response with status and timestamp",
-        "operationId": "agent_heartbeat_agent__agent_id__session__session_id__heartbeat_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "title": "Agent Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "session_id",
-            "required": true,
-            "schema": {
-              "title": "Session Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Agent Heartbeat"
-      }
-    },
-    "/agent/{agent_id}/session/{session_id}/instructions/stream": {
-      "get": {
-        "description": "SSE endpoint for streaming instructions to agents for a specific session",
-        "operationId": "stream_instructions_agent__agent_id__session__session_id__instructions_stream_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "title": "Agent Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "session_id",
-            "required": true,
-            "schema": {
-              "title": "Session Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Stream Instructions"
-      }
-    },
-    "/agent/{agent_id}/session/{session_id}/instructions/{instruction_id}/ack": {
-      "post": {
-        "description": "HTTP endpoint for instruction acknowledgements with database persistence",
-        "operationId": "acknowledge_instruction_agent__agent_id__session__session_id__instructions__instruction_id__ack_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "agent_id",
-            "required": true,
-            "schema": {
-              "title": "Agent Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "session_id",
-            "required": true,
-            "schema": {
-              "title": "Session Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "instruction_id",
-            "required": true,
-            "schema": {
-              "title": "Instruction Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AgentInstructionAcknowledgement"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentInstructionAcknowledgementResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Acknowledge Instruction"
-      }
-    },
-    "/atlas-tiles": {
-      "get": {
-        "description": "Get all atlas tiles",
-        "operationId": "get_atlas_tiles_atlas_tiles_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AtlasTileResponse"
-                  },
-                  "title": "Response Get Atlas Tiles Atlas Tiles Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Atlas Tiles"
-      }
-    },
-    "/atlas-tiles/{tile_uuid}": {
-      "delete": {
-        "description": "Delete an atlas tile by publishing to RabbitMQ",
-        "operationId": "delete_atlas_tile_atlas_tiles__tile_uuid__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "tile_uuid",
-            "required": true,
-            "schema": {
-              "title": "Tile Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Atlas Tile"
-      },
-      "get": {
-        "description": "Get a single atlas tile by ID",
-        "operationId": "get_atlas_tile_atlas_tiles__tile_uuid__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "tile_uuid",
-            "required": true,
-            "schema": {
-              "title": "Tile Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasTileResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Atlas Tile"
-      },
-      "put": {
-        "description": "Update an atlas tile",
-        "operationId": "update_atlas_tile_atlas_tiles__tile_uuid__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "tile_uuid",
-            "required": true,
-            "schema": {
-              "title": "Tile Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AtlasTileUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasTileResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Atlas Tile"
-      }
-    },
-    "/atlas-tiles/{tile_uuid}/gridsquares": {
-      "post": {
-        "description": "Connect mutliple grid squares to a tile with its position information",
-        "operationId": "link_atlas_tile_to_gridsquares_atlas_tiles__tile_uuid__gridsquares_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "tile_uuid",
-            "required": true,
-            "schema": {
-              "title": "Tile Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "items": {
-                  "$ref": "#/components/schemas/GridSquarePositionRequest"
-                },
-                "title": "Gridsquare Positions",
-                "type": "array"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
-                  },
-                  "title": "Response Link Atlas Tile To Gridsquares Atlas Tiles  Tile Uuid  Gridsquares Post",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Link Atlas Tile To Gridsquares"
-      }
-    },
-    "/atlas-tiles/{tile_uuid}/gridsquares/{gridsquare_uuid}": {
-      "post": {
-        "description": "Connect a grid square to a tile with its position information",
-        "operationId": "link_atlas_tile_to_gridsquare_atlas_tiles__tile_uuid__gridsquares__gridsquare_uuid__post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "tile_uuid",
-            "required": true,
-            "schema": {
-              "title": "Tile Uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridSquarePositionRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Link Atlas Tile To Gridsquare"
-      }
-    },
-    "/atlases": {
-      "get": {
-        "description": "Get all atlases",
-        "operationId": "get_atlases_atlases_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AtlasResponse"
-                  },
-                  "title": "Response Get Atlases Atlases Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Atlases"
-      }
-    },
-    "/atlases/{atlas_uuid}": {
-      "delete": {
-        "description": "Delete an atlas by publishing to RabbitMQ",
-        "operationId": "delete_atlas_atlases__atlas_uuid__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "atlas_uuid",
-            "required": true,
-            "schema": {
-              "title": "Atlas Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Atlas"
-      },
-      "get": {
-        "description": "Get a single atlas by ID",
-        "operationId": "get_atlas_atlases__atlas_uuid__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "atlas_uuid",
-            "required": true,
-            "schema": {
-              "title": "Atlas Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Atlas"
-      },
-      "put": {
-        "description": "Update an atlas",
-        "operationId": "update_atlas_atlases__atlas_uuid__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "atlas_uuid",
-            "required": true,
-            "schema": {
-              "title": "Atlas Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AtlasUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Atlas"
-      }
-    },
-    "/atlases/{atlas_uuid}/tiles": {
-      "get": {
-        "description": "Get all tiles for a specific atlas",
-        "operationId": "get_atlas_tiles_by_atlas_atlases__atlas_uuid__tiles_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "atlas_uuid",
-            "required": true,
-            "schema": {
-              "title": "Atlas Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AtlasTileResponse"
-                  },
-                  "title": "Response Get Atlas Tiles By Atlas Atlases  Atlas Uuid  Tiles Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Atlas Tiles By Atlas"
-      },
-      "post": {
-        "description": "Create a new tile for a specific atlas",
-        "operationId": "create_atlas_tile_for_atlas_atlases__atlas_uuid__tiles_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "atlas_uuid",
-            "required": true,
-            "schema": {
-              "title": "Atlas Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AtlasTileCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasTileResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Atlas Tile For Atlas"
-      }
-    },
-    "/debug/agent-connections": {
-      "get": {
-        "description": "Debug endpoint to view active agent connections",
-        "operationId": "get_active_connections_debug_agent_connections_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Active Connections"
-      }
-    },
-    "/debug/connection-stats": {
-      "get": {
-        "description": "Get real-time connection and session statistics",
-        "operationId": "get_connection_stats_debug_connection_stats_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Connection Stats"
-      }
-    },
-    "/debug/session/{session_id}/create-instruction": {
-      "post": {
-        "description": "Debug endpoint to create test instructions",
-        "operationId": "create_test_instruction_debug_session__session_id__create_instruction_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "session_id",
-            "required": true,
-            "schema": {
-              "title": "Session Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "title": "Instruction Data",
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Test Instruction"
-      }
-    },
-    "/debug/session/{session_id}/instructions": {
-      "get": {
-        "description": "Debug endpoint to view instructions for a session",
-        "operationId": "get_session_instructions_debug_session__session_id__instructions_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "session_id",
-            "required": true,
-            "schema": {
-              "title": "Session Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Session Instructions"
-      }
-    },
-    "/debug/sessions": {
-      "get": {
-        "description": "Debug endpoint to view all active sessions",
-        "operationId": "get_active_sessions_debug_sessions_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Active Sessions"
-      }
-    },
-    "/debug/sessions/create": {
-      "post": {
-        "description": "Debug endpoint to create test sessions",
-        "operationId": "create_test_session_debug_sessions_create_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "title": "Session Data",
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Test Session"
-      }
-    },
-    "/debug/sessions/create-managed": {
-      "post": {
-        "description": "Create a session using the connection manager",
-        "operationId": "create_managed_session_debug_sessions_create_managed_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "title": "Session Data",
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Managed Session"
-      }
-    },
-    "/debug/sessions/{session_id}/close": {
-      "delete": {
-        "description": "Close a session using the connection manager",
-        "operationId": "close_managed_session_debug_sessions__session_id__close_delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "session_id",
-            "required": true,
-            "schema": {
-              "title": "Session Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Close Managed Session"
-      }
-    },
-    "/foilholes": {
-      "get": {
-        "description": "Get all foil holes",
-        "operationId": "get_foilholes_foilholes_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/FoilHoleResponse"
-                  },
-                  "title": "Response Get Foilholes Foilholes Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Foilholes"
-      }
-    },
-    "/foilholes/{foilhole_uuid}": {
-      "delete": {
-        "description": "Delete a foil hole by publishing to RabbitMQ",
-        "operationId": "delete_foilhole_foilholes__foilhole_uuid__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "foilhole_uuid",
-            "required": true,
-            "schema": {
-              "title": "Foilhole Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Foilhole"
-      },
-      "get": {
-        "description": "Get a single foil hole by ID",
-        "operationId": "get_foilhole_foilholes__foilhole_uuid__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "foilhole_uuid",
-            "required": true,
-            "schema": {
-              "title": "Foilhole Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FoilHoleResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Foilhole"
-      },
-      "put": {
-        "description": "Update a foil hole",
-        "operationId": "update_foilhole_foilholes__foilhole_uuid__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "foilhole_uuid",
-            "required": true,
-            "schema": {
-              "title": "Foilhole Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FoilHoleUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FoilHoleResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Foilhole"
-      }
-    },
-    "/foilholes/{foilhole_uuid}/micrographs": {
-      "get": {
-        "description": "Get all micrographs for a specific foil hole",
-        "operationId": "get_foilhole_micrographs_foilholes__foilhole_uuid__micrographs_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "foilhole_uuid",
-            "required": true,
-            "schema": {
-              "title": "Foilhole Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/MicrographResponse"
-                  },
-                  "title": "Response Get Foilhole Micrographs Foilholes  Foilhole Uuid  Micrographs Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Foilhole Micrographs"
-      },
-      "post": {
-        "description": "Create a new micrograph for a specific foil hole",
-        "operationId": "create_foilhole_micrograph_foilholes__foilhole_uuid__micrographs_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "foilhole_uuid",
-            "required": true,
-            "schema": {
-              "title": "Foilhole Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MicrographCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MicrographResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Foilhole Micrograph"
-      }
-    },
-    "/grid/{grid_uuid}/model_weights": {
-      "get": {
-        "description": "Get time series of model weights for grid",
-        "operationId": "get_model_weights_for_grid_grid__grid_uuid__model_weights_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "items": {
-                      "$ref": "#/components/schemas/QualityPredictionModelWeight"
-                    },
-                    "type": "array"
-                  },
-                  "title": "Response Get Model Weights For Grid Grid  Grid Uuid  Model Weights Get",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Model Weights For Grid"
-      }
-    },
-    "/grid/{grid_uuid}/prediction_model/{prediction_model_name}/latent_rep/{latent_rep_model_name}/suggested_squares": {
-      "get": {
-        "operationId": "get_suggested_square_collections_grid__grid_uuid__prediction_model__prediction_model_name__latent_rep__latent_rep_model_name__suggested_squares_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "prediction_model_name",
-            "required": true,
-            "schema": {
-              "title": "Prediction Model Name",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "latent_rep_model_name",
-            "required": true,
-            "schema": {
-              "title": "Latent Rep Model Name",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GridSquare"
-                  },
-                  "title": "Response Get Suggested Square Collections Grid  Grid Uuid  Prediction Model  Prediction Model Name  Latent Rep  Latent Rep Model Name  Suggested Squares Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Suggested Square Collections"
-      }
-    },
-    "/grids": {
-      "get": {
-        "description": "Get all grids",
-        "operationId": "get_grids_grids_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GridResponse"
-                  },
-                  "title": "Response Get Grids Grids Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Grids"
-      }
-    },
-    "/grids/{grid_uuid}": {
-      "delete": {
-        "description": "Delete a grid by publishing to RabbitMQ",
-        "operationId": "delete_grid_grids__grid_uuid__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Grid"
-      },
-      "get": {
-        "description": "Get a single grid by ID",
-        "operationId": "get_grid_grids__grid_uuid__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Grid"
-      },
-      "put": {
-        "description": "Update a grid",
-        "operationId": "update_grid_grids__grid_uuid__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Grid"
-      }
-    },
-    "/grids/{grid_uuid}/atlas": {
-      "get": {
-        "description": "Get the atlas for a specific grid",
-        "operationId": "get_grid_atlas_grids__grid_uuid__atlas_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Grid Atlas"
-      },
-      "post": {
-        "description": "Create a new atlas for a grid",
-        "operationId": "create_grid_atlas_grids__grid_uuid__atlas_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AtlasCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AtlasResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Grid Atlas"
-      }
-    },
-    "/grids/{grid_uuid}/atlas_image": {
-      "get": {
-        "description": "Get a single grid by ID",
-        "operationId": "get_grid_atlas_image_grids__grid_uuid__atlas_image_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "x",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X"
-            }
-          },
-          {
-            "in": "query",
-            "name": "y",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Y"
-            }
-          },
-          {
-            "in": "query",
-            "name": "w",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "W"
-            }
-          },
-          {
-            "in": "query",
-            "name": "h",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "H"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              },
-              "image/png": {}
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Grid Atlas Image"
-      }
-    },
-    "/grids/{grid_uuid}/gridsquares": {
-      "get": {
-        "description": "Get all grid squares for a specific grid",
-        "operationId": "get_grid_gridsquares_grids__grid_uuid__gridsquares_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GridSquareResponse"
-                  },
-                  "title": "Response Get Grid Gridsquares Grids  Grid Uuid  Gridsquares Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Grid Gridsquares"
-      },
-      "post": {
-        "description": "Create a new grid square for a specific grid",
-        "operationId": "create_grid_gridsquare_grids__grid_uuid__gridsquares_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridSquareCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridSquareResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Grid Gridsquare"
-      }
-    },
-    "/grids/{grid_uuid}/gridsquares/batch": {
-      "post": {
-        "description": "Create many grid squares for a grid in a single transaction and a single\nbatched RabbitMQ publish. Solves the overload scenario from issue #249.",
-        "operationId": "create_grid_gridsquares_batch_grids__grid_uuid__gridsquares_batch_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridSquareBatchCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridSquareBatchCreateResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Grid Gridsquares Batch"
-      }
-    },
-    "/grids/{grid_uuid}/registered": {
-      "post": {
-        "description": "All squares on a grid have been registered at low mag",
-        "operationId": "grid_registered_grids__grid_uuid__registered_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Response Grid Registered Grids  Grid Uuid  Registered Post",
-                  "type": "boolean"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Grid Registered"
-      }
-    },
-    "/gridsquare/{gridsquare_uuid}/overall_prediction": {
-      "get": {
-        "operationId": "get_overall_prediction_for_gridsquare_gridsquare__gridsquare_uuid__overall_prediction_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/OverallQualityPrediction"
-                  },
-                  "title": "Response Get Overall Prediction For Gridsquare Gridsquare  Gridsquare Uuid  Overall Prediction Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Overall Prediction For Gridsquare"
-      }
-    },
-    "/gridsquares": {
-      "get": {
-        "description": "Get all grid squares",
-        "operationId": "get_gridsquares_gridsquares_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GridSquareResponse"
-                  },
-                  "title": "Response Get Gridsquares Gridsquares Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Gridsquares"
-      }
-    },
-    "/gridsquares/{gridsquare_uuid}": {
-      "delete": {
-        "description": "Delete a grid square by publishing to RabbitMQ",
-        "operationId": "delete_gridsquare_gridsquares__gridsquare_uuid__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Gridsquare"
-      },
-      "get": {
-        "description": "Get a single grid square by ID",
-        "operationId": "get_gridsquare_gridsquares__gridsquare_uuid__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridSquareResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Gridsquare"
-      },
-      "put": {
-        "description": "Update a grid square",
-        "operationId": "update_gridsquare_gridsquares__gridsquare_uuid__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GridSquareUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GridSquareResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Gridsquare"
-      }
-    },
-    "/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
-      "get": {
-        "description": "Get time ordered predictions for all models that provide them for this square",
-        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "additionalProperties": {
-                      "items": {
-                        "$ref": "#/components/schemas/QualityPrediction"
-                      },
-                      "type": "array"
-                    },
-                    "type": "object"
-                  },
-                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare"
-      }
-    },
-    "/gridsquares/{gridsquare_uuid}/foilholes": {
-      "get": {
-        "description": "Get all foil holes for a specific grid square",
-        "operationId": "get_gridsquare_foilholes_gridsquares__gridsquare_uuid__foilholes_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "on_square_only",
-            "required": false,
-            "schema": {
-              "default": false,
-              "title": "On Square Only",
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/FoilHoleResponse"
-                  },
-                  "title": "Response Get Gridsquare Foilholes Gridsquares  Gridsquare Uuid  Foilholes Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Gridsquare Foilholes"
-      },
-      "post": {
-        "description": "Create a new foil hole for a specific grid square",
-        "operationId": "create_gridsquare_foilhole_gridsquares__gridsquare_uuid__foilholes_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "items": {
-                  "$ref": "#/components/schemas/FoilHoleCreateRequest"
-                },
-                "title": "Foilholes",
-                "type": "array"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/FoilHoleResponse"
-                  },
-                  "title": "Response Create Gridsquare Foilhole Gridsquares  Gridsquare Uuid  Foilholes Post",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Gridsquare Foilhole"
-      }
-    },
-    "/gridsquares/{gridsquare_uuid}/gridsquare_image": {
-      "get": {
-        "description": "Get a single grid square by ID",
-        "operationId": "get_gridsquare_image_gridsquares__gridsquare_uuid__gridsquare_image_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              },
-              "image/png": {}
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Gridsquare Image"
-      }
-    },
-    "/gridsquares/{gridsquare_uuid}/quality_predictions": {
-      "get": {
-        "description": "Get time ordered predictions for all models that provide them for this square",
-        "operationId": "get_gridsquare_quality_prediction_time_series_gridsquares__gridsquare_uuid__quality_predictions_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "items": {
-                      "$ref": "#/components/schemas/QualityPrediction"
-                    },
-                    "type": "array"
-                  },
-                  "title": "Response Get Gridsquare Quality Prediction Time Series Gridsquares  Gridsquare Uuid  Quality Predictions Get",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Gridsquare Quality Prediction Time Series"
-      }
-    },
-    "/gridsquares/{gridsquare_uuid}/registered": {
-      "post": {
-        "description": "All holes on a grid square have been registered at square mag",
-        "operationId": "gridsquare_registered_gridsquares__gridsquare_uuid__registered_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "count",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Count"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Response Gridsquare Registered Gridsquares  Gridsquare Uuid  Registered Post",
-                  "type": "boolean"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Gridsquare Registered"
-      }
-    },
-    "/health": {
-      "get": {
-        "description": "Health check endpoint with actual connectivity checks",
-        "operationId": "get_health_health_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Health"
-      }
-    },
-    "/micrographs": {
-      "get": {
-        "description": "Get all micrographs",
-        "operationId": "get_micrographs_micrographs_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/MicrographResponse"
-                  },
-                  "title": "Response Get Micrographs Micrographs Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Micrographs"
-      }
-    },
-    "/micrographs/{micrograph_uuid}": {
-      "delete": {
-        "description": "Delete a micrograph by publishing to RabbitMQ",
-        "operationId": "delete_micrograph_micrographs__micrograph_uuid__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "micrograph_uuid",
-            "required": true,
-            "schema": {
-              "title": "Micrograph Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Micrograph"
-      },
-      "get": {
-        "description": "Get a single micrograph by ID",
-        "operationId": "get_micrograph_micrographs__micrograph_uuid__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "micrograph_uuid",
-            "required": true,
-            "schema": {
-              "title": "Micrograph Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MicrographResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Micrograph"
-      },
-      "put": {
-        "description": "Update a micrograph",
-        "operationId": "update_micrograph_micrographs__micrograph_uuid__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "micrograph_uuid",
-            "required": true,
-            "schema": {
-              "title": "Micrograph Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MicrographUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MicrographResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Micrograph"
-      }
-    },
-    "/micrographs/{micrograph_uuid}/ctf_estimation/completed": {
-      "post": {
-        "description": "Publish a CTF-estimation-completed event for a micrograph to RabbitMQ.",
-        "operationId": "publish_micrograph_ctf_estimation_completed_micrographs__micrograph_uuid__ctf_estimation_completed_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "micrograph_uuid",
-            "required": true,
-            "schema": {
-              "title": "Micrograph Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CtfEstimationCompletedRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Publish Micrograph Ctf Estimation Completed"
-      }
-    },
-    "/micrographs/{micrograph_uuid}/ctf_estimation/registered": {
-      "post": {
-        "description": "Publish a CTF-estimation-registered event for a micrograph to RabbitMQ.",
-        "operationId": "publish_micrograph_ctf_estimation_registered_micrographs__micrograph_uuid__ctf_estimation_registered_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "micrograph_uuid",
-            "required": true,
-            "schema": {
-              "title": "Micrograph Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CtfEstimationRegisteredRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Publish Micrograph Ctf Estimation Registered"
-      }
-    },
-    "/micrographs/{micrograph_uuid}/motion_correction/completed": {
-      "post": {
-        "description": "Publish a motion-correction-completed event for a micrograph to RabbitMQ.",
-        "operationId": "publish_micrograph_motion_correction_completed_micrographs__micrograph_uuid__motion_correction_completed_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "micrograph_uuid",
-            "required": true,
-            "schema": {
-              "title": "Micrograph Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MotionCorrectionCompletedRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Publish Micrograph Motion Correction Completed"
-      }
-    },
-    "/micrographs/{micrograph_uuid}/motion_correction/registered": {
-      "post": {
-        "description": "Publish a motion-correction-registered event for a micrograph to RabbitMQ.",
-        "operationId": "publish_micrograph_motion_correction_registered_micrographs__micrograph_uuid__motion_correction_registered_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "micrograph_uuid",
-            "required": true,
-            "schema": {
-              "title": "Micrograph Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MotionCorrectionRegisteredRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Publish Micrograph Motion Correction Registered"
-      }
-    },
-    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/latent_representation": {
-      "get": {
-        "operationId": "get_latent_rep_prediction_model__prediction_model_name__grid__grid_uuid__latent_representation_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "prediction_model_name",
-            "required": true,
-            "schema": {
-              "title": "Prediction Model Name",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/LatentRepresentationResponse"
-                  },
-                  "title": "Response Get Latent Rep Prediction Model  Prediction Model Name  Grid  Grid Uuid  Latent Representation Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Latent Rep"
-      }
-    },
-    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/prediction": {
-      "get": {
-        "operationId": "get_prediction_for_grid_prediction_model__prediction_model_name__grid__grid_uuid__prediction_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "prediction_model_name",
-            "required": true,
-            "schema": {
-              "title": "Prediction Model Name",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "grid_uuid",
-            "required": true,
-            "schema": {
-              "title": "Grid Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/QualityPredictionResponse"
-                  },
-                  "title": "Response Get Prediction For Grid Prediction Model  Prediction Model Name  Grid  Grid Uuid  Prediction Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Prediction For Grid"
-      }
-    },
-    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/latent_representation": {
-      "get": {
-        "operationId": "get_square_latent_rep_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__latent_representation_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "prediction_model_name",
-            "required": true,
-            "schema": {
-              "title": "Prediction Model Name",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/LatentRepresentationResponse"
-                  },
-                  "title": "Response Get Square Latent Rep Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Latent Representation Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Square Latent Rep"
-      }
-    },
-    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/prediction": {
-      "get": {
-        "operationId": "get_prediction_for_gridsquare_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__prediction_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "prediction_model_name",
-            "required": true,
-            "schema": {
-              "title": "Prediction Model Name",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/QualityPredictionResponse"
-                  },
-                  "title": "Response Get Prediction For Gridsquare Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Prediction Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Prediction For Gridsquare"
-      }
-    },
-    "/prediction_models": {
-      "get": {
-        "operationId": "get_prediction_models_prediction_models_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/QualityPredictionModelResponse"
-                  },
-                  "title": "Response Get Prediction Models Prediction Models Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Prediction Models"
-      },
-      "post": {
-        "operationId": "create_prediction_model_prediction_models_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/QualityPredictionModelCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Prediction Model"
-      }
-    },
-    "/prediction_models/{name}": {
-      "delete": {
-        "operationId": "delete_prediction_model_prediction_models__name__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "schema": {
-              "title": "Name",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Prediction Model"
-      },
-      "get": {
-        "operationId": "get_prediction_model_prediction_models__name__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "schema": {
-              "title": "Name",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Prediction Model"
-      },
-      "put": {
-        "operationId": "update_prediction_model_prediction_models__name__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "name",
-            "required": true,
-            "schema": {
-              "title": "Name",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/QualityPredictionModelUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Prediction Model"
-      }
-    },
-    "/quality_metric/{metric_name}/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
-      "get": {
-        "description": "Get time ordered predictions for all models that provide them for this square",
-        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_for_metric_quality_metric__metric_name__gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "metric_name",
-            "required": true,
-            "schema": {
-              "title": "Metric Name",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "gridsquare_uuid",
-            "required": true,
-            "schema": {
-              "title": "Gridsquare Uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "additionalProperties": {
-                      "items": {
-                        "$ref": "#/components/schemas/QualityPrediction"
-                      },
-                      "type": "array"
-                    },
-                    "type": "object"
-                  },
-                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare For Metric Quality Metric  Metric Name  Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare For Metric"
-      }
-    },
-    "/quality_metrics": {
-      "get": {
-        "operationId": "get_quality_metrics_quality_metrics_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityMetricsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Quality Metrics"
-      }
-    },
-    "/quality_predictions": {
-      "post": {
-        "operationId": "create_quality_prediction_quality_predictions_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/QualityPredictionCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QualityPredictionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Quality Prediction"
-      }
-    },
-    "/status": {
-      "get": {
-        "description": "Get API status and configuration information",
-        "operationId": "get_status_status_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Status"
-      }
+  "servers": [
+    {
+      "url": "http://localhost:8001",
+      "description": "Local development server"
     }
-  }
+  ]
 }

--- a/webui/public/api/smartem/swagger.json
+++ b/webui/public/api/smartem/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "SmartEM Decisions Backend API",
     "description": "API for accessing and managing electron microscopy data",
-    "version": "0.1.dev276+g1b7ed28d6.d20250818"
+    "version": "0.1.1rc48.dev3+gcd5206327"
   },
   "paths": {
     "/status": {
@@ -93,6 +93,29 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/acquisitions/grid-counts": {
+      "get": {
+        "summary": "Get Acquisition Grid Counts",
+        "description": "Per-acquisition grid totals for summary views.\n\nA single grouped query in place of one /acquisitions/{uuid}/grids call per\nacquisition. Every acquisition is returned, including those with no grids\n(grids_total == 0), via an outer join. Declared before the\n/acquisitions/{acquisition_uuid} route so the static segment is matched\nfirst rather than being parsed as a uuid.",
+        "operationId": "get_acquisition_grid_counts_acquisitions_grid_counts_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AcquisitionGridCountResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Acquisition Grid Counts Acquisitions Grid Counts Get"
                 }
               }
             }
@@ -1017,6 +1040,64 @@
         }
       }
     },
+    "/atlas-tiles/{tile_uuid}/gridsquares": {
+      "post": {
+        "summary": "Link Atlas Tile To Gridsquares",
+        "description": "Connect mutliple grid squares to a tile with its position information",
+        "operationId": "link_atlas_tile_to_gridsquares_atlas_tiles__tile_uuid__gridsquares_post",
+        "parameters": [
+          {
+            "name": "tile_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tile Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GridSquarePositionRequest"
+                },
+                "title": "Gridsquare Positions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
+                  },
+                  "title": "Response Link Atlas Tile To Gridsquares Atlas Tiles  Tile Uuid  Gridsquares Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/gridsquares": {
       "get": {
         "summary": "Get Gridsquares",
@@ -1251,6 +1332,56 @@
         }
       }
     },
+    "/grids/{grid_uuid}/gridsquares/batch": {
+      "post": {
+        "summary": "Create Grid Gridsquares Batch",
+        "description": "Create many grid squares for a grid in a single transaction and a single\nbatched RabbitMQ publish. Solves the overload scenario from issue #249.",
+        "operationId": "create_grid_gridsquares_batch_grids__grid_uuid__gridsquares_batch_post",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareBatchCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareBatchCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/gridsquares/{gridsquare_uuid}/registered": {
       "post": {
         "summary": "Gridsquare Registered",
@@ -1264,6 +1395,22 @@
             "schema": {
               "type": "string",
               "title": "Gridsquare Uuid"
+            }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Count"
             }
           }
         ],
@@ -1448,6 +1595,16 @@
               "type": "string",
               "title": "Gridsquare Uuid"
             }
+          },
+          {
+            "name": "on_square_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "On Square Only"
+            }
           }
         ],
         "responses": {
@@ -1497,7 +1654,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/FoilHoleCreateRequest"
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FoilHoleCreateRequest"
+                },
+                "title": "Foilholes"
               }
             }
           }
@@ -1508,7 +1669,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FoilHoleResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "title": "Response Create Gridsquare Foilhole Gridsquares  Gridsquare Uuid  Foilholes Post"
                 }
               }
             }
@@ -1668,6 +1833,206 @@
         }
       }
     },
+    "/micrographs/{micrograph_uuid}/motion_correction/completed": {
+      "post": {
+        "summary": "Publish Micrograph Motion Correction Completed",
+        "description": "Publish a motion-correction-completed event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_motion_correction_completed_micrographs__micrograph_uuid__motion_correction_completed_post",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MotionCorrectionCompletedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/micrographs/{micrograph_uuid}/motion_correction/registered": {
+      "post": {
+        "summary": "Publish Micrograph Motion Correction Registered",
+        "description": "Publish a motion-correction-registered event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_motion_correction_registered_micrographs__micrograph_uuid__motion_correction_registered_post",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MotionCorrectionRegisteredRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/micrographs/{micrograph_uuid}/ctf_estimation/completed": {
+      "post": {
+        "summary": "Publish Micrograph Ctf Estimation Completed",
+        "description": "Publish a CTF-estimation-completed event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_ctf_estimation_completed_micrographs__micrograph_uuid__ctf_estimation_completed_post",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CtfEstimationCompletedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/micrographs/{micrograph_uuid}/ctf_estimation/registered": {
+      "post": {
+        "summary": "Publish Micrograph Ctf Estimation Registered",
+        "description": "Publish a CTF-estimation-registered event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_ctf_estimation_registered_micrographs__micrograph_uuid__ctf_estimation_registered_post",
+        "parameters": [
+          {
+            "name": "micrograph_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Micrograph Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CtfEstimationRegisteredRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/foilholes/{foilhole_uuid}/micrographs": {
       "get": {
         "summary": "Get Foilhole Micrographs",
@@ -1744,6 +2109,1444 @@
                 "schema": {
                   "$ref": "#/components/schemas/MicrographResponse"
                 }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_models": {
+      "get": {
+        "summary": "Get Prediction Models",
+        "operationId": "get_prediction_models_prediction_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Get Prediction Models Prediction Models Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Prediction Model",
+        "operationId": "create_prediction_model_prediction_models_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionModelCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_models/{name}": {
+      "get": {
+        "summary": "Get Prediction Model",
+        "operationId": "get_prediction_model_prediction_models__name__get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update Prediction Model",
+        "operationId": "update_prediction_model_prediction_models__name__put",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionModelUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Prediction Model",
+        "operationId": "delete_prediction_model_prediction_models__name__delete",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/quality_predictions": {
+      "get": {
+        "summary": "Get Gridsquare Quality Prediction Time Series",
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_gridsquare_quality_prediction_time_series_gridsquares__gridsquare_uuid__quality_predictions_get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/QualityPrediction"
+                    }
+                  },
+                  "title": "Response Get Gridsquare Quality Prediction Time Series Gridsquares  Gridsquare Uuid  Quality Predictions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
+      "get": {
+        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare",
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/QualityPrediction"
+                      }
+                    }
+                  },
+                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quality_predictions": {
+      "post": {
+        "summary": "Create Quality Prediction",
+        "operationId": "create_quality_prediction_quality_predictions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quality_metrics": {
+      "get": {
+        "summary": "Get Quality Metrics",
+        "operationId": "get_quality_metrics_quality_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityMetricsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/prediction": {
+      "get": {
+        "summary": "Get Prediction For Grid",
+        "operationId": "get_prediction_for_grid_prediction_model__prediction_model_name__grid__grid_uuid__prediction_get",
+        "parameters": [
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionResponse"
+                  },
+                  "title": "Response Get Prediction For Grid Prediction Model  Prediction Model Name  Grid  Grid Uuid  Prediction Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/latent_representation": {
+      "get": {
+        "summary": "Get Latent Rep",
+        "operationId": "get_latent_rep_prediction_model__prediction_model_name__grid__grid_uuid__latent_representation_get",
+        "parameters": [
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LatentRepresentationResponse"
+                  },
+                  "title": "Response Get Latent Rep Prediction Model  Prediction Model Name  Grid  Grid Uuid  Latent Representation Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/instructions/stream": {
+      "get": {
+        "summary": "Stream Instructions",
+        "description": "SSE endpoint for streaming instructions to agents for a specific session.\n\nUses PostgreSQL LISTEN/NOTIFY (channel `agent_instructions`, payload = session_id)\ninstead of polling: a dedicated asyncpg connection holds a LISTEN, the main loop\nawaits the next notification or a heartbeat timeout, and only queries the\ndatabase when a notification arrives or on initial connect.",
+        "operationId": "stream_instructions_agent__agent_id__session__session_id__instructions_stream_get",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/instructions/{instruction_id}/ack": {
+      "post": {
+        "summary": "Acknowledge Instruction",
+        "description": "HTTP endpoint for instruction acknowledgements with database persistence",
+        "operationId": "acknowledge_instruction_agent__agent_id__session__session_id__instructions__instruction_id__ack_post",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "instruction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Instruction Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstructionAcknowledgement"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstructionAcknowledgementResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/heartbeat": {
+      "post": {
+        "summary": "Agent Heartbeat",
+        "description": "Agent heartbeat endpoint to update connection health status.\n\nArgs:\n    agent_id: The agent identifier\n    session_id: The session identifier\n    db: Database session\n\nReturns:\n    Heartbeat response with status and timestamp",
+        "operationId": "agent_heartbeat_agent__agent_id__session__session_id__heartbeat_post",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/agent-connections": {
+      "get": {
+        "summary": "Get Active Connections",
+        "description": "Debug endpoint to view active agent connections",
+        "operationId": "get_active_connections_debug_agent_connections_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/session/{session_id}/instructions": {
+      "get": {
+        "summary": "Get Session Instructions",
+        "description": "Debug endpoint to view instructions for a session",
+        "operationId": "get_session_instructions_debug_session__session_id__instructions_get",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/sessions": {
+      "get": {
+        "summary": "Get Active Sessions",
+        "description": "Debug endpoint to view all active sessions",
+        "operationId": "get_active_sessions_debug_sessions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/connection-stats": {
+      "get": {
+        "summary": "Get Connection Stats",
+        "description": "Get real-time connection and session statistics",
+        "operationId": "get_connection_stats_debug_connection_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/sessions/create-managed": {
+      "post": {
+        "summary": "Create Managed Session",
+        "description": "Create a session using the connection manager",
+        "operationId": "create_managed_session_debug_sessions_create_managed_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Session Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/sessions/{session_id}/close": {
+      "delete": {
+        "summary": "Close Managed Session",
+        "description": "Close a session using the connection manager",
+        "operationId": "close_managed_session_debug_sessions__session_id__close_delete",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/session/{session_id}/create-instruction": {
+      "post": {
+        "summary": "Create Test Instruction",
+        "description": "Debug endpoint to create test instructions",
+        "operationId": "create_test_instruction_debug_session__session_id__create_instruction_post",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Instruction Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/debug/sessions/create": {
+      "post": {
+        "summary": "Create Test Session",
+        "description": "Debug endpoint to create test sessions",
+        "operationId": "create_test_session_debug_sessions_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Session Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grid/{grid_uuid}/model_weights": {
+      "get": {
+        "summary": "Get Model Weights For Grid",
+        "description": "Get time series of model weights for grid",
+        "operationId": "get_model_weights_for_grid_grid__grid_uuid__model_weights_get",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/QualityPredictionModelWeight"
+                    }
+                  },
+                  "title": "Response Get Model Weights For Grid Grid  Grid Uuid  Model Weights Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/quality_metric/{metric_name}/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
+      "get": {
+        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare For Metric",
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_for_metric_quality_metric__metric_name__gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
+        "parameters": [
+          {
+            "name": "metric_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Metric Name"
+            }
+          },
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/QualityPrediction"
+                      }
+                    }
+                  },
+                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare For Metric Quality Metric  Metric Name  Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/prediction": {
+      "get": {
+        "summary": "Get Prediction For Gridsquare",
+        "operationId": "get_prediction_for_gridsquare_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__prediction_get",
+        "parameters": [
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionResponse"
+                  },
+                  "title": "Response Get Prediction For Gridsquare Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Prediction Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquare/{gridsquare_uuid}/overall_prediction": {
+      "get": {
+        "summary": "Get Overall Prediction For Gridsquare",
+        "operationId": "get_overall_prediction_for_gridsquare_gridsquare__gridsquare_uuid__overall_prediction_get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OverallQualityPrediction"
+                  },
+                  "title": "Response Get Overall Prediction For Gridsquare Gridsquare  Gridsquare Uuid  Overall Prediction Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grid/{grid_uuid}/prediction_model/{prediction_model_name}/latent_rep/{latent_rep_model_name}/suggested_squares": {
+      "get": {
+        "summary": "Get Suggested Square Collections",
+        "operationId": "get_suggested_square_collections_grid__grid_uuid__prediction_model__prediction_model_name__latent_rep__latent_rep_model_name__suggested_squares_get",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          },
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "latent_rep_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Latent Rep Model Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquare"
+                  },
+                  "title": "Response Get Suggested Square Collections Grid  Grid Uuid  Prediction Model  Prediction Model Name  Latent Rep  Latent Rep Model Name  Suggested Squares Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/latent_representation": {
+      "get": {
+        "summary": "Get Square Latent Rep",
+        "operationId": "get_square_latent_rep_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__latent_representation_get",
+        "parameters": [
+          {
+            "name": "prediction_model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Model Name"
+            }
+          },
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LatentRepresentationResponse"
+                  },
+                  "title": "Response Get Square Latent Rep Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Latent Representation Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/grids/{grid_uuid}/atlas_image": {
+      "get": {
+        "summary": "Get Grid Atlas Image",
+        "description": "Get a single grid by ID",
+        "operationId": "get_grid_atlas_image_grids__grid_uuid__atlas_image_get",
+        "parameters": [
+          {
+            "name": "grid_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grid Uuid"
+            }
+          },
+          {
+            "name": "x",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X"
+            }
+          },
+          {
+            "name": "y",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Y"
+            }
+          },
+          {
+            "name": "w",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "W"
+            }
+          },
+          {
+            "name": "h",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "H"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "image/png": {}
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/gridsquare_image": {
+      "get": {
+        "summary": "Get Gridsquare Image",
+        "description": "Get a single grid square by ID",
+        "operationId": "get_gridsquare_image_gridsquares__gridsquare_uuid__gridsquare_image_get",
+        "parameters": [
+          {
+            "name": "gridsquare_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Gridsquare Uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "image/png": {}
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/logs": {
+      "post": {
+        "summary": "Ingest Agent Logs",
+        "operationId": "ingest_agent_logs_agent__agent_id__session__session_id__logs_post",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentLogBatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentLogBatchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/frontend/events/stream": {
+      "get": {
+        "summary": "Frontend Event Stream",
+        "operationId": "frontend_event_stream_frontend_events_stream_get",
+        "parameters": [
+          {
+            "name": "acquisition_uuid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Acquisition Uuid"
+            }
+          },
+          {
+            "name": "agent_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "event_types",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Types"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
               }
             }
           },
@@ -1905,10 +3708,27 @@
           }
         },
         "type": "object",
-        "required": [
-          "uuid"
-        ],
+        "required": ["uuid"],
         "title": "AcquisitionCreateRequest"
+      },
+      "AcquisitionGridCountResponse": {
+        "properties": {
+          "acquisition_uuid": {
+            "type": "string",
+            "title": "Acquisition Uuid"
+          },
+          "grids_total": {
+            "type": "integer",
+            "title": "Grids Total"
+          },
+          "grids_completed": {
+            "type": "integer",
+            "title": "Grids Completed"
+          }
+        },
+        "type": "object",
+        "required": ["acquisition_uuid", "grids_total", "grids_completed"],
+        "title": "AcquisitionGridCountResponse"
       },
       "AcquisitionResponse": {
         "properties": {
@@ -2064,13 +3884,7 @@
       },
       "AcquisitionStatus": {
         "type": "string",
-        "enum": [
-          "planned",
-          "started",
-          "completed",
-          "paused",
-          "abandoned"
-        ],
+        "enum": ["planned", "started", "completed", "paused", "abandoned"],
         "title": "AcquisitionStatus"
       },
       "AcquisitionUpdateRequest": {
@@ -2224,6 +4038,142 @@
         "type": "object",
         "title": "AcquisitionUpdateRequest"
       },
+      "AgentInstructionAcknowledgement": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["received", "processed", "failed", "declined"],
+            "title": "Status"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "processing_time_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processing Time Ms"
+          },
+          "processed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processed At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["status"],
+        "title": "AgentInstructionAcknowledgement",
+        "description": "Request model for instruction acknowledgements from agents"
+      },
+      "AgentInstructionAcknowledgementResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "instruction_id": {
+            "type": "string",
+            "title": "Instruction Id"
+          },
+          "acknowledged_at": {
+            "type": "string",
+            "title": "Acknowledged At"
+          },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          }
+        },
+        "type": "object",
+        "required": ["status", "instruction_id", "acknowledged_at", "agent_id", "session_id"],
+        "title": "AgentInstructionAcknowledgementResponse",
+        "description": "Response model for instruction acknowledgement confirmations"
+      },
+      "AgentLogBatchRequest": {
+        "properties": {
+          "logs": {
+            "items": {
+              "$ref": "#/components/schemas/AgentLogEntry"
+            },
+            "type": "array",
+            "title": "Logs"
+          }
+        },
+        "type": "object",
+        "required": ["logs"],
+        "title": "AgentLogBatchRequest"
+      },
+      "AgentLogBatchResponse": {
+        "properties": {
+          "stored": {
+            "type": "integer",
+            "title": "Stored"
+          }
+        },
+        "type": "object",
+        "required": ["stored"],
+        "title": "AgentLogBatchResponse"
+      },
+      "AgentLogEntry": {
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "level": {
+            "type": "string",
+            "title": "Level"
+          },
+          "logger_name": {
+            "type": "string",
+            "title": "Logger Name"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": ["timestamp", "level", "logger_name", "message"],
+        "title": "AgentLogEntry"
+      },
       "AtlasCreateRequest": {
         "properties": {
           "uuid": {
@@ -2299,11 +4249,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "uuid",
-          "grid_uuid",
-          "name"
-        ],
+        "required": ["uuid", "grid_uuid", "name"],
         "title": "AtlasCreateRequest"
       },
       "AtlasResponse": {
@@ -2475,10 +4421,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "uuid",
-          "atlas_uuid"
-        ],
+        "required": ["uuid", "atlas_uuid"],
         "title": "AtlasTileCreateRequest"
       },
       "AtlasTileGridSquarePositionResponse": {
@@ -2803,6 +4746,39 @@
         "type": "object",
         "title": "AtlasUpdateRequest"
       },
+      "CtfEstimationCompletedRequest": {
+        "properties": {
+          "ctf_max_res": {
+            "type": "number",
+            "title": "Ctf Max Res"
+          }
+        },
+        "type": "object",
+        "required": ["ctf_max_res"],
+        "title": "CtfEstimationCompletedRequest"
+      },
+      "CtfEstimationRegisteredRequest": {
+        "properties": {
+          "quality": {
+            "type": "boolean",
+            "title": "Quality"
+          },
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          }
+        },
+        "type": "object",
+        "required": ["quality"],
+        "title": "CtfEstimationRegisteredRequest"
+      },
       "FoilHoleCreateRequest": {
         "properties": {
           "uuid": {
@@ -2959,12 +4935,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "uuid",
-          "foilhole_id",
-          "gridsquare_id",
-          "gridsquare_uuid"
-        ],
+        "required": ["uuid", "foilhole_id", "gridsquare_id", "gridsquare_uuid"],
         "title": "FoilHoleCreateRequest"
       },
       "FoilHoleResponse": {
@@ -2989,7 +4960,14 @@
             "title": "Foilhole Id"
           },
           "status": {
-            "$ref": "#/components/schemas/FoilHoleStatus"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoilHoleStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "center_x": {
             "anyOf": [
@@ -3140,10 +5118,7 @@
       },
       "FoilHoleStatus": {
         "type": "string",
-        "enum": [
-          "none",
-          "micrographs detected"
-        ],
+        "enum": ["none", "micrographs detected"],
         "title": "FoilHoleStatus"
       },
       "FoilHoleUpdateRequest": {
@@ -3404,11 +5379,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "uuid",
-          "name",
-          "acquisition_uuid"
-        ],
+        "required": ["uuid", "name", "acquisition_uuid"],
         "title": "GridCreateRequest"
       },
       "GridResponse": {
@@ -3501,6 +5472,309 @@
           "scan_end_time"
         ],
         "title": "GridResponse"
+      },
+      "GridSquare": {
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "title": "Uuid"
+          },
+          "grid_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grid Uuid"
+          },
+          "status": {
+            "$ref": "#/components/schemas/GridSquareStatus",
+            "default": "none"
+          },
+          "gridsquare_id": {
+            "type": "string",
+            "title": "Gridsquare Id",
+            "default": ""
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "atlas_node_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Node Id"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
+          "selected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected"
+          },
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unusable"
+          },
+          "stage_position_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position X"
+          },
+          "stage_position_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Y"
+          },
+          "stage_position_z": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Z"
+          },
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
+          }
+        },
+        "type": "object",
+        "required": ["uuid"],
+        "title": "GridSquare"
+      },
+      "GridSquareBatchCreateRequest": {
+        "properties": {
+          "gridsquares": {
+            "items": {
+              "$ref": "#/components/schemas/GridSquareCreateRequest"
+            },
+            "type": "array",
+            "title": "Gridsquares"
+          }
+        },
+        "type": "object",
+        "required": ["gridsquares"],
+        "title": "GridSquareBatchCreateRequest"
+      },
+      "GridSquareBatchCreateResponse": {
+        "properties": {
+          "gridsquares": {
+            "items": {
+              "$ref": "#/components/schemas/GridSquareResponse"
+            },
+            "type": "array",
+            "title": "Gridsquares"
+          }
+        },
+        "type": "object",
+        "required": ["gridsquares"],
+        "title": "GridSquareBatchCreateResponse",
+        "description": "Response for bulk grid-square creation."
       },
       "GridSquareCreateRequest": {
         "properties": {
@@ -3776,11 +6050,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "uuid",
-          "gridsquare_id",
-          "grid_uuid"
-        ],
+        "required": ["uuid", "gridsquare_id", "grid_uuid"],
         "title": "GridSquareCreateRequest"
       },
       "GridSquarePositionRequest": {
@@ -3800,15 +6070,21 @@
           "size_height": {
             "type": "integer",
             "title": "Size Height"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
           }
         },
         "type": "object",
-        "required": [
-          "center_x",
-          "center_y",
-          "size_width",
-          "size_height"
-        ],
+        "required": ["center_x", "center_y", "size_width", "size_height"],
         "title": "GridSquarePositionRequest"
       },
       "GridSquareResponse": {
@@ -4121,6 +6397,7 @@
         "type": "string",
         "enum": [
           "none",
+          "all foil holes registered",
           "foil holes decision started",
           "foil holes decision completed"
         ],
@@ -4542,6 +6819,56 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
+      "LatentRepresentationResponse": {
+        "properties": {
+          "x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X"
+          },
+          "y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y"
+          },
+          "index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index"
+          },
+          "gridsquare_uuid": {
+            "type": "string",
+            "title": "Gridsquare Uuid",
+            "default": ""
+          },
+          "foilhole_uuid": {
+            "type": "string",
+            "title": "Foilhole Uuid",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": ["x", "y", "index"],
+        "title": "LatentRepresentationResponse"
+      },
       "MicrographCreateRequest": {
         "properties": {
           "uuid": {
@@ -4790,10 +7117,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "uuid",
-          "foilhole_id"
-        ],
+        "required": ["uuid", "foilhole_id"],
         "title": "MicrographCreateRequest"
       },
       "MicrographResponse": {
@@ -5054,11 +7378,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "uuid",
-          "foilhole_uuid",
-          "status"
-        ],
+        "required": ["uuid", "foilhole_uuid", "status"],
         "title": "MicrographResponse"
       },
       "MicrographStatus": {
@@ -5340,6 +7660,542 @@
         "type": "object",
         "title": "MicrographUpdateRequest"
       },
+      "MotionCorrectionCompletedRequest": {
+        "properties": {
+          "total_motion": {
+            "type": "number",
+            "title": "Total Motion"
+          },
+          "average_motion": {
+            "type": "number",
+            "title": "Average Motion"
+          }
+        },
+        "type": "object",
+        "required": ["total_motion", "average_motion"],
+        "title": "MotionCorrectionCompletedRequest"
+      },
+      "MotionCorrectionRegisteredRequest": {
+        "properties": {
+          "quality": {
+            "type": "boolean",
+            "title": "Quality"
+          },
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          }
+        },
+        "type": "object",
+        "required": ["quality"],
+        "title": "MotionCorrectionRegisteredRequest"
+      },
+      "OverallQualityPrediction": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "suggested_acquisition_index": {
+            "type": "integer",
+            "title": "Suggested Acquisition Index"
+          },
+          "foilhole_uuid": {
+            "type": "string",
+            "title": "Foilhole Uuid"
+          },
+          "grid_uuid": {
+            "type": "string",
+            "title": "Grid Uuid"
+          },
+          "gridsquare_uuid": {
+            "type": "string",
+            "title": "Gridsquare Uuid"
+          }
+        },
+        "type": "object",
+        "required": [
+          "value",
+          "suggested_acquisition_index",
+          "foilhole_uuid",
+          "grid_uuid",
+          "gridsquare_uuid"
+        ],
+        "title": "OverallQualityPrediction"
+      },
+      "ProcessingFeedbackPublishResponse": {
+        "properties": {
+          "published": {
+            "type": "boolean",
+            "title": "Published"
+          }
+        },
+        "type": "object",
+        "required": ["published"],
+        "title": "ProcessingFeedbackPublishResponse",
+        "description": "Confirmation that a processing-feedback event was published to RabbitMQ."
+      },
+      "QualityMetricsResponse": {
+        "properties": {
+          "total_predictions": {
+            "type": "integer",
+            "title": "Total Predictions"
+          },
+          "average_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Quality"
+          },
+          "min_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Quality"
+          },
+          "max_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Quality"
+          },
+          "models_count": {
+            "type": "integer",
+            "title": "Models Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total_predictions",
+          "average_quality",
+          "min_quality",
+          "max_quality",
+          "models_count"
+        ],
+        "title": "QualityMetricsResponse"
+      },
+      "QualityPrediction": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
+          },
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          }
+        },
+        "type": "object",
+        "required": ["value", "prediction_model_name"],
+        "title": "QualityPrediction"
+      },
+      "QualityPredictionCreateRequest": {
+        "properties": {
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
+          },
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          }
+        },
+        "type": "object",
+        "required": ["value", "prediction_model_name"],
+        "title": "QualityPredictionCreateRequest"
+      },
+      "QualityPredictionModelCreateRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": ""
+          },
+          "can_train": {
+            "type": "boolean",
+            "title": "Can Train",
+            "default": false
+          },
+          "can_infer": {
+            "type": "boolean",
+            "title": "Can Infer",
+            "default": true
+          },
+          "can_update": {
+            "type": "boolean",
+            "title": "Can Update",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": ["name"],
+        "title": "QualityPredictionModelCreateRequest"
+      },
+      "QualityPredictionModelParameterResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "grid_uuid": {
+            "type": "string",
+            "title": "Grid Uuid"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "group": {
+            "type": "string",
+            "title": "Group"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "grid_uuid",
+          "timestamp",
+          "prediction_model_name",
+          "key",
+          "value",
+          "group"
+        ],
+        "title": "QualityPredictionModelParameterResponse"
+      },
+      "QualityPredictionModelResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "can_train": {
+            "type": "boolean",
+            "title": "Can Train"
+          },
+          "can_infer": {
+            "type": "boolean",
+            "title": "Can Infer"
+          },
+          "can_update": {
+            "type": "boolean",
+            "title": "Can Update"
+          }
+        },
+        "type": "object",
+        "required": ["name", "description", "can_train", "can_infer", "can_update"],
+        "title": "QualityPredictionModelResponse"
+      },
+      "QualityPredictionModelUpdateRequest": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "can_train": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Train"
+          },
+          "can_infer": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Infer"
+          },
+          "can_update": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Update"
+          }
+        },
+        "type": "object",
+        "title": "QualityPredictionModelUpdateRequest"
+      },
+      "QualityPredictionModelWeight": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "grid_uuid": {
+            "type": "string",
+            "title": "Grid Uuid"
+          },
+          "micrograph_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Micrograph Uuid"
+          },
+          "micrograph_quality": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Micrograph Quality"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
+          },
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "weight": {
+            "type": "number",
+            "title": "Weight"
+          },
+          "prediction_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prediction Value"
+          },
+          "quality_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Score"
+          }
+        },
+        "type": "object",
+        "required": ["grid_uuid", "prediction_model_name", "weight"],
+        "title": "QualityPredictionModelWeight"
+      },
+      "QualityPredictionResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "prediction_model_name": {
+            "type": "string",
+            "title": "Prediction Model Name"
+          },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          },
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          }
+        },
+        "type": "object",
+        "required": ["id", "prediction_model_name", "value", "timestamp"],
+        "title": "QualityPredictionResponse"
+      },
       "ValidationError": {
         "properties": {
           "loc": {
@@ -5366,11 +8222,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
+        "required": ["loc", "msg", "type"],
         "title": "ValidationError"
       }
     }


### PR DESCRIPTION
## Summary

Regenerates the committed SmartEM `swagger.json` from the current backend via the canonical `tools/generate_api_docs.py` (run against smartem-decisions `main`). Both copies were stale and mutually inconsistent:

| File | Was | Now |
|---|---|---|
| `webui/public/api/smartem/swagger.json` (served on Pages) | `0.1.dev276…d20250818` — **25 paths, Aug 2025** | `0.1.1rc48…` — **61 paths** |
| `docs/api/smartem/swagger.json` | `0.1.1rc27…d20260416` — 58 paths, Apr 2026 | **61 paths** |

Both are now byte-identical, current, and include `/acquisitions/grid-counts` (smartem-decisions#291). The large diff is a one-off: `webui/public` jumps 36 paths, and `docs/` is normalised from a non-canonical sorted-key layout to the generator's insertion-order output, so future `generate_api_docs.py` runs won't reformat it.

## Why

- The Pages-served spec was ~9 months stale — the human-facing SmartEM API reference (Swagger UI) was wrong.
- It also **un-breaks `npm run api:update` in smartem-frontend**, which `curl`s the Pages-served copy; against the old 25-path spec it would regenerate a badly regressed client (dropping ~36 endpoints).

## Effect on merge

`deploy-webui.yml` runs on push to `main`, so merging redeploys GitHub Pages and the live `…/api/smartem/swagger.json` will reflect the current backend.

## Verification

- Generated via the documented tool against backend `main` (`app.openapi()`), 61 paths, `grid-counts` present.
- Both committed copies verified identical (same sha) and valid JSON.
- Pre-commit (biome) + pre-push (typecheck/lint/format-check/gitleaks) all pass.

## Related

- smartem-decisions#291 (endpoint), smartem-frontend#108 (dashboard consumer)
- Underlying gap: there is no automation syncing the backend spec into this repo — this refresh is manual. A follow-up could wire backend `main` to regenerate + PR these files automatically.