### PR TITLE
feat: mount local DLS-filesystem mirror into dev backend for image serving

### DIFF
--- a/packages/smartem-workspace/pyproject.toml
+++ b/packages/smartem-workspace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "smartem-workspace"
-version = "0.6.1"
+version = "0.7.0"
 description = "CLI tool to automate SmartEM multi-repo workspace setup"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/smartem-workspace/smartem_workspace/__init__.py
+++ b/packages/smartem-workspace/smartem_workspace/__init__.py
@@ -1,3 +1,3 @@
 """SmartEM workspace setup CLI tool."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/packages/smartem-workspace/smartem_workspace/setup/workspace.py
+++ b/packages/smartem-workspace/smartem_workspace/setup/workspace.py
@@ -15,6 +15,9 @@ def setup_workspace_structure(workspace_path: Path) -> bool:
     - repos/
     - tmp/
     - testdata/
+    - testdata/dls-filesystem/  (local mirror of Diamond's /dls shared filesystem;
+      populated by hand with microscopy imagery and mounted into the dev backend
+      pod at /dls so image-serving endpoints can resolve DB /dls/... paths)
 
     Returns:
         True if successful
@@ -26,6 +29,8 @@ def setup_workspace_structure(workspace_path: Path) -> bool:
         "repos",
         "tmp",
         "testdata",
+        # Mirrors Diamond's /dls DFS root; mounted into the dev backend at /dls.
+        "testdata/dls-filesystem",
     ]
 
     for dir_name in directories:

--- a/scripts/k8s/dev-k8s.sh
+++ b/scripts/k8s/dev-k8s.sh
@@ -419,6 +419,46 @@ ensure_local_image() {
     fi
 }
 
+# Mount the local DLS-filesystem mirror into the API pod so image-serving endpoints can
+# read atlas/grid-square files that the DB references by absolute /dls/... paths. hostPath
+# must be absolute and kustomize can't template, so (like the configmap/secret steps) we
+# patch the live deployment here. API service only: the worker never reads image files.
+# The mirror lives at <workspace>/testdata/dls-filesystem by convention; override with
+# SMARTEM_DLS_FILESYSTEM_DIR. Skipped silently when absent (images show placeholders).
+ensure_image_mount() {
+    local workspace_root dls_dir
+    workspace_root="$(cd "$PROJECT_ROOT/../../.." 2>/dev/null && pwd)"
+    dls_dir="${SMARTEM_DLS_FILESYSTEM_DIR:-$workspace_root/testdata/dls-filesystem}"
+
+    if [[ ! -d "$dls_dir" ]]; then
+        log_info "No DLS-filesystem mirror at $dls_dir - skipping image mount (atlas/grid-square images will show placeholders)"
+        return 0
+    fi
+
+    log_info "Mounting DLS-filesystem mirror into smartem-http-api: $dls_dir -> /dls"
+    if kubectl patch deployment smartem-http-api -n "$NAMESPACE" --type strategic --patch "$(cat <<PATCH
+spec:
+  template:
+    spec:
+      containers:
+        - name: smartem-http-api
+          volumeMounts:
+            - name: dls-filesystem
+              mountPath: /dls
+              readOnly: true
+      volumes:
+        - name: dls-filesystem
+          hostPath:
+            path: $dls_dir
+            type: Directory
+PATCH
+)" &> /dev/null; then
+        log_success "DLS-filesystem mount applied to smartem-http-api"
+    else
+        log_warning "Could not apply DLS-filesystem mount (non-fatal; images will show placeholders)"
+    fi
+}
+
 # Deploy the environment
 deploy_environment() {
     log_info "Deploying development environment..."
@@ -439,6 +479,9 @@ deploy_environment() {
 
     # Ensure local image is built and available for development
     ensure_local_image
+
+    # Mount the local DLS-filesystem mirror so the API can serve atlas/grid-square images
+    ensure_image_mount
 
     log_success "Deployment initiated"
 }


### PR DESCRIPTION
## Summary

The backend image endpoints (`get_grid_atlas_image`, `get_gridsquare_image`) read atlas/grid-square files off disk using the absolute `/dls/...` paths stored in the DB. Against a DB dump those files aren't present, so images fall back to placeholders. This mounts a local mirror of Diamond's `/dls` filesystem into the dev API pod so the endpoints resolve, giving us real imagery in local dev.

## Changes

- **smartem-workspace**: scaffold `testdata/dls-filesystem/` as the convention dir — a local mirror of Diamond's `/dls` DFS root, populated by hand with microscopy imagery. Version bump `0.6.1 -> 0.7.0`.
- **dev-k8s.sh**: new `ensure_image_mount` step patches `smartem-http-api` with a hostPath `<workspace>/testdata/dls-filesystem -> /dls` (readOnly), overridable via `SMARTEM_DLS_FILESYSTEM_DIR`, skipped silently when the dir is absent.

## Why a script patch and not the static manifest

`hostPath` must be absolute, and the dev stack applies manifests with `kubectl apply -k` (kustomize, no templating), so a portable per-developer path can't live in the committed YAML. This mirrors the existing post-apply patch pattern (`ensure_app_configmap`, `ensure_ghcr_secret`, `ensure_local_image`) and keeps any machine-specific path out of the repo.

## Scope

- **API service only** — verified the worker never reads image files from disk (the only `mrcfile`/`tifffile`/PIL reads in the backend are the two API image endpoints; the worker is a pure MQ->DB consumer).
- Local dev only. The staging/prod `/dls` NFS mount is a separate PR.

## Notes

- Merging to `main` triggers an RC release of smartem-workspace (paths-filtered workflow); a stable `0.7.0` would need the tag/`workflow_dispatch`.
