### PR TITLE
docs: DLS filesystem mount placeholder for prod/stage API

### DIFF
--- a/k8s/environments/production/smartem-http-api.yaml
+++ b/k8s/environments/production/smartem-http-api.yaml
@@ -56,6 +56,25 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "500m"
+        # --- DLS filesystem mount (PLACEHOLDER - configure before enabling) ---
+        # The image-serving API endpoints (atlas_image, gridsquare_image) read microscopy
+        # files off disk using the absolute /dls/... paths stored in the DB. Mount the real
+        # Diamond /dls shared filesystem read-only at /dls so they resolve. API service only:
+        # the worker does not read image files. Set the source to the actual DLS NFS export
+        # or a PVC bound to it for this cluster, then uncomment both blocks.
+        # volumeMounts:
+        # - name: dls-filesystem
+        #   mountPath: /dls
+        #   readOnly: true
+      # volumes:
+      # - name: dls-filesystem
+      #   nfs:
+      #     server: <dls-nfs-server>   # DLS NFS/GPFS export host
+      #     path: /dls                 # export containing <scope>/data/<year>/<visit>/...
+      #     readOnly: true
+      #   # or bind to a PersistentVolumeClaim instead of nfs:
+      #   # persistentVolumeClaim:
+      #   #   claimName: dls-filesystem
 
 ---
 

--- a/k8s/environments/staging/smartem-http-api.yaml
+++ b/k8s/environments/staging/smartem-http-api.yaml
@@ -55,6 +55,25 @@ spec:
           limits:
             memory: "256Mi"
             cpu: "200m"
+        # --- DLS filesystem mount (PLACEHOLDER - configure before enabling) ---
+        # The image-serving API endpoints (atlas_image, gridsquare_image) read microscopy
+        # files off disk using the absolute /dls/... paths stored in the DB. Mount the real
+        # Diamond /dls shared filesystem read-only at /dls so they resolve. API service only:
+        # the worker does not read image files. Set the source to the actual DLS NFS export
+        # or a PVC bound to it for this cluster, then uncomment both blocks.
+        # volumeMounts:
+        # - name: dls-filesystem
+        #   mountPath: /dls
+        #   readOnly: true
+      # volumes:
+      # - name: dls-filesystem
+      #   nfs:
+      #     server: <dls-nfs-server>   # DLS NFS/GPFS export host
+      #     path: /dls                 # export containing <scope>/data/<year>/<visit>/...
+      #     readOnly: true
+      #   # or bind to a PersistentVolumeClaim instead of nfs:
+      #   # persistentVolumeClaim:
+      #   #   claimName: dls-filesystem
 
 ---
 


### PR DESCRIPTION
## Summary

The image-serving API endpoints (`atlas_image`, `gridsquare_image`) read microscopy files off disk using the absolute `/dls/...` paths stored in the DB. For staging/production to serve images, the real Diamond `/dls` shared filesystem needs mounting into the `smartem-http-api` pod at `/dls`.

This adds a **commented placeholder** (NFS or PVC) to the production and staging `smartem-http-api` deployments. It's inert until someone uncomments it and fills in the real DLS NFS export / PVC for that cluster.

## Changes

- `k8s/environments/production/smartem-http-api.yaml` — commented `/dls` mount placeholder.
- `k8s/environments/staging/smartem-http-api.yaml` — same.

## Notes

- **API service only** — the worker does not read image files from disk.
- No behavioural change until configured and uncommented.
- The local-dev equivalent (hostPath mount via dev-k8s.sh) is a separate PR (#223).
- @ for whoever owns the stage/prod cluster wiring to fill in the NFS/PVC source.
