### PR TITLE
fix(k8s/dev): raise dev API limits to 1Gi/1 for image serving

### DIFF
--- a/k8s/environments/development/smartem-http-api.yaml
+++ b/k8s/environments/development/smartem-http-api.yaml
@@ -55,9 +55,12 @@ spec:
           requests:
             memory: "128Mi"
             cpu: "100m"
+          # Image endpoints decode 31MB+ MRC/TIFF files to PNG; under a grid/atlas page's
+          # request fan-out this overruns a 256Mi/200m pod (OOMKill + slow encodes). Give the
+          # dev API headroom so local image-serving stays stable.
           limits:
-            memory: "256Mi"
-            cpu: "200m"
+            memory: "1Gi"
+            cpu: "1"
 
 ---
 


### PR DESCRIPTION
## Summary

The dev `smartem-http-api` pod is limited to **256Mi / 200m cpu**. The image-serving endpoints (`/grids/{id}/atlas_image`, `/gridsquares/{id}/gridsquare_image`) decode **31MB+ MRC/TIFF** files to PNG, and under a grid/atlas page's request fan-out that overruns the limit — the pod **OOMKills and restarts** (502s + checkered placeholders), and encodes take ~15s. This bumps the **development** limits to **1Gi / 1 cpu** so local image serving stays stable.

## Why now

This was applied as a live `kubectl set resources` patch during image-rendering testing, but it isn't in git — so every `dev-k8s.sh` redeploy (`kubectl apply -k`) reverted it and reintroduced the OOM. Landing it here makes redeploys durable and removes the manual re-patch step. Pairs with the `/dls` mount handling already in `dev-k8s.sh` (`ensure_image_mount`).

## Scope

- **Development environment only.** Requests stay at 128Mi/100m (Burstable QoS).
- Stage/prod manifests are untouched — their sizing is a separate decision.
- `kubectl kustomize k8s/environments/development` builds clean and renders `memory: 1Gi`, `cpu: "1"`.