### PR TITLE
ci: clear Node 20 action deprecations

### DIFF
--- a/.github/workflows/leaked-secrets-scan.yml
+++ b/.github/workflows/leaked-secrets-scan.yml
@@ -33,7 +33,7 @@ jobs:
         run: gitleaks detect --source . --redact -c .gitleaks.toml -v --report-format sarif --report-path gitleaks-report.sarif
       - name: Upload SARIF to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: gitleaks-report.sarif
           category: gitleaks

--- a/.github/workflows/pr-admin.yml
+++ b/.github/workflows/pr-admin.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Add PR to SmartEM project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/DiamondLightSource/projects/51
           github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/release-smartem-epuplayer.yml
+++ b/.github/workflows/release-smartem-epuplayer.yml
@@ -477,7 +477,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@26e8ad27a09a225049a7075d7ec1caa2df6ff332 # v2.6.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ needs.version.outputs.is_stable == 'true' && format('epuplayer-v{0}', needs.version.outputs.version) || format('epuplayer-v{0}', needs.version.outputs.version) }}
           name: EPUPlayer v${{ needs.version.outputs.version }}

--- a/.github/workflows/release-smartem-workspace.yml
+++ b/.github/workflows/release-smartem-workspace.yml
@@ -336,7 +336,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@26e8ad27a09a225049a7075d7ec1caa2df6ff332 # v2.6.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ needs.version.outputs.is_stable == 'true' && format('smartem-workspace-v{0}', needs.version.outputs.version) || format('smartem-workspace-v{0}', needs.version.outputs.version) }}
           name: smartem-workspace v${{ needs.version.outputs.version }}


### PR DESCRIPTION
## What

Bump the actions still running on Node.js 20 across this repo's workflows.

| Action | Workflow(s) | Change | Why |
|--------|-------------|--------|-----|
| `github/codeql-action/upload-sarif` | `leaked-secrets-scan.yml` | `@v3` → `@v4` | Node 20 deprecation **and** "CodeQL Action v3 deprecated Dec 2026, move to v4" — v4 clears both |
| `softprops/action-gh-release` | `release-smartem-workspace.yml`, `release-smartem-epuplayer.yml` | `v2.6.0` → `v3.0.0` (`b4309332981a82ec1c5618f44dd2e27cc8bfbfda`) | Node 20 deprecation; v3.0.0 is a pure runtime bump (Node 20 → 24), no functional changes. SHA-pin preserved. |
| `actions/add-to-project` | `pr-admin.yml` | `@v1.0.2` → `@v2.0.0` | Node 20 → v2.0.0 runs on Node 24 |

## How I found them

Live warning annotations from recent runs **plus** static resolution of each `action.yml` `using:` runtime. The latter mattered here: the **epuplayer** softprops pin and **add-to-project** didn't surface in annotations because their workflows last ran before GitHub's Node 20 annotation rollout (or the step was skipped) — annotations alone would have missed them. Verified all three targets declare `using: node24`.

With this merged, no workflow action here emits a Node 20 deprecation warning, ahead of the 2026-06-16 default flip and 2026-09-16 runner removal.