### PR TITLE
More environment variables in deployments

### DIFF
--- a/k8s/environments/development/smartem-http-api.yaml
+++ b/k8s/environments/development/smartem-http-api.yaml
@@ -68,6 +68,11 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: RABBITMQ_HOST
+        - name: RABBITMQ_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_PORT
         - name: RABBITMQ_EXCHANGE
           valueFrom:
             secretKeyRef:

--- a/k8s/environments/development/smartem-http-api.yaml
+++ b/k8s/environments/development/smartem-http-api.yaml
@@ -38,6 +38,21 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: POSTGRES_PASSWORD
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_HOST
+        - name: POSTGRES_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_PORT
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_DB
         - name: RABBITMQ_USER
           valueFrom:
             secretKeyRef:
@@ -48,6 +63,16 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: RABBITMQ_PASSWORD
+        - name: RABBITMQ_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_HOST
+        - name: RABBITMQ_EXCHANGE
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_EXCHANGE
         envFrom:
         - configMapRef:
             name: smartem-config

--- a/k8s/environments/development/smartem-worker.yaml
+++ b/k8s/environments/development/smartem-worker.yaml
@@ -36,6 +36,21 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: POSTGRES_PASSWORD
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_HOST
+        - name: POSTGRES_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_PORT
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_DB
         - name: RABBITMQ_USER
           valueFrom:
             secretKeyRef:
@@ -46,6 +61,21 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: RABBITMQ_PASSWORD
+        - name: RABBITMQ_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_HOST
+        - name: RABBITMQ_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_PORT
+        - name: RABBITMQ_EXCHANGE
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_EXCHANGE
         envFrom:
         - configMapRef:
             name: smartem-config

--- a/k8s/environments/production/smartem-http-api.yaml
+++ b/k8s/environments/production/smartem-http-api.yaml
@@ -66,6 +66,11 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: RABBITMQ_HOST
+        - name: RABBITMQ_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_PORT
         - name: RABBITMQ_EXCHANGE
           valueFrom:
             secretKeyRef:

--- a/k8s/environments/production/smartem-http-api.yaml
+++ b/k8s/environments/production/smartem-http-api.yaml
@@ -36,6 +36,21 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: POSTGRES_PASSWORD
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_HOST
+        - name: POSTGRES_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_PORT
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_DB
         - name: RABBITMQ_USER
           valueFrom:
             secretKeyRef:
@@ -46,6 +61,16 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: RABBITMQ_PASSWORD
+        - name: RABBITMQ_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_HOST
+        - name: RABBITMQ_EXCHANGE
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_EXCHANGE
         envFrom:
         - configMapRef:
             name: smartem-config

--- a/k8s/environments/production/smartem-worker.yaml
+++ b/k8s/environments/production/smartem-worker.yaml
@@ -34,6 +34,21 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: POSTGRES_PASSWORD
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_HOST
+        - name: POSTGRES_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_PORT
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_DB
         - name: RABBITMQ_USER
           valueFrom:
             secretKeyRef:
@@ -44,6 +59,21 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: RABBITMQ_PASSWORD
+        - name: RABBITMQ_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_HOST
+        - name: RABBITMQ_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_PORT
+        - name: RABBITMQ_EXCHANGE
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_EXCHANGE
         envFrom:
         - configMapRef:
             name: smartem-config

--- a/k8s/environments/staging/smartem-http-api.yaml
+++ b/k8s/environments/staging/smartem-http-api.yaml
@@ -35,6 +35,21 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: POSTGRES_PASSWORD
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_HOST
+        - name: POSTGRES_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_PORT
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_DB
         - name: RABBITMQ_USER
           valueFrom:
             secretKeyRef:
@@ -45,6 +60,16 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: RABBITMQ_PASSWORD
+        - name: RABBITMQ_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_HOST
+        - name: RABBITMQ_EXCHANGE
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_EXCHANGE
         envFrom:
         - configMapRef:
             name: smartem-config

--- a/k8s/environments/staging/smartem-http-api.yaml
+++ b/k8s/environments/staging/smartem-http-api.yaml
@@ -65,6 +65,11 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: RABBITMQ_HOST
+        - name: RABBITMQ_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_PORT
         - name: RABBITMQ_EXCHANGE
           valueFrom:
             secretKeyRef:

--- a/k8s/environments/staging/smartem-worker.yaml
+++ b/k8s/environments/staging/smartem-worker.yaml
@@ -33,6 +33,21 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: POSTGRES_PASSWORD
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_HOST
+        - name: POSTGRES_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_PORT
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: POSTGRES_DB
         - name: RABBITMQ_USER
           valueFrom:
             secretKeyRef:
@@ -43,6 +58,21 @@ spec:
             secretKeyRef:
               name: smartem-secrets
               key: RABBITMQ_PASSWORD
+        - name: RABBITMQ_HOST
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_HOST
+        - name: RABBITMQ_PORT
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_PORT
+        - name: RABBITMQ_EXCHANGE
+          valueFrom:
+            secretKeyRef:
+              name: smartem-secrets
+              key: RABBITMQ_EXCHANGE
         envFrom:
         - configMapRef:
             name: smartem-config


### PR DESCRIPTION
Some postgres and rabbitmq credentials/configuration environment variables are not set in the HTTP API and worker deployments. This adds the missing ones extracting them from the same secret as the pre-existing ones